### PR TITLE
Add temporary banner asking for feedback

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -28,8 +28,9 @@ html
     link(rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&family=Roboto+Mono:wght@400;600&display=swap")
 
   body(class="no-js")
-    div(class="info-oldversion" role="banner")
-      p Go back to #[a(href="https://simpleicons.org/" rel="noopener") the old design] or #[button(id="hide-oldversion" disabled) hide this message].
+    div(class="banner-feedback" role="banner")
+      p #[a(href="https://github.com/simple-icons/simple-icons/discussions/4865" rel="noopener") Share your opinion of the redesign on GitHub] or #[a(href="https://simpleicons.org/" rel="noopener") Go to the old design] or #[button(id="hide-feedback-banner" disabled) Hide this message].
+
     header(class="header" role="banner")
       ul(class="header__list")
         li(class="header__list-item")

--- a/public/index.pug
+++ b/public/index.pug
@@ -29,7 +29,8 @@ html
 
   body(class="no-js")
     div(class="banner-feedback" role="banner")
-      p #[a(href="https://github.com/simple-icons/simple-icons/discussions/4865" rel="noopener") Share your opinion of the redesign on GitHub] or #[a(href="https://simpleicons.org/" rel="noopener") Go to the old design] or #[button(id="hide-feedback-banner" disabled) Hide this message].
+      span #[a(href="https://github.com/simple-icons/simple-icons/discussions/4865" rel="noopener") Share your opinion of the redesign on GitHub] or #[a(href="https://simpleicons.org/" rel="noopener") Go to the old design]
+      span(class="banner__hide") Hide this message #[button(id="hide-feedback-banner-once" disabled) Once] or #[button(id="hide-feedback-banner" disabled) Always]
 
     header(class="header" role="banner")
       ul(class="header__list")

--- a/public/index.pug
+++ b/public/index.pug
@@ -28,6 +28,8 @@ html
     link(rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&family=Roboto+Mono:wght@400;600&display=swap")
 
   body(class="no-js")
+    div(class="info-oldversion" role="banner")
+      p Go back to #[a(href="https://simpleicons.org/" rel="noopener") the old design] or #[button(id="hide-oldversion" disabled) hide this message].
     header(class="header" role="banner")
       ul(class="header__list")
         li(class="header__list-item")

--- a/public/scripts/feedback-request.js
+++ b/public/scripts/feedback-request.js
@@ -1,7 +1,7 @@
 import { hideElement } from './dom-utils.js';
 import { STORAGE_HIDE_TEMP_BANNER } from './storage.js';
 
-export default function initCopyButtons(document, storage) {
+export default function initFeedbackRequest(document, storage) {
   const $feedbackBanner = document.querySelector('.banner-feedback');
   const $hideAlwaysButton = document.getElementById('hide-feedback-banner');
   const $hideOnceButton = document.getElementById('hide-feedback-banner-once');

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -4,7 +4,7 @@ import initCopyButtons from './copy.js';
 import initColorScheme from './color-scheme.js';
 import initOrdering from './ordering.js';
 import initSearch from './search.js';
-import initOldVersion from './oldversion.js';
+import initFeedbackRequest from './feedback-request.js';
 import newStorage from './storage.js';
 
 document.body.classList.remove('no-js');
@@ -14,4 +14,4 @@ initColorScheme(document, storage);
 initCopyButtons(document, navigator);
 const orderingControls = initOrdering(document, storage);
 initSearch(window.history, document, orderingControls);
-initOldVersion(document, storage);
+initFeedbackRequest(document, storage);

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -4,7 +4,8 @@ import initCopyButtons from './copy.js';
 import initColorScheme from './color-scheme.js';
 import initOrdering from './ordering.js';
 import initSearch from './search.js';
-import newStorage from './storage';
+import initOldVersion from './oldversion.js';
+import newStorage from './storage.js';
 
 document.body.classList.remove('no-js');
 
@@ -13,3 +14,4 @@ initColorScheme(document, storage);
 initCopyButtons(document, navigator);
 const orderingControls = initOrdering(document, storage);
 initSearch(window.history, document, orderingControls);
+initOldVersion(document, storage);

--- a/public/scripts/oldversion.js
+++ b/public/scripts/oldversion.js
@@ -2,19 +2,25 @@ import { hideElement } from './dom-utils.js';
 import { STORAGE_HIDE_TEMP_BANNER } from './storage.js';
 
 export default function initCopyButtons(document, storage) {
-  const $infoBanner = document.querySelector('.banner-feedback');
-  const $hideInfoButton = document.getElementById('hide-feedback-banner');
+  const $feedbackBanner = document.querySelector('.banner-feedback');
+  const $hideAlwaysButton = document.getElementById('hide-feedback-banner');
+  const $hideOnceButton = document.getElementById('hide-feedback-banner-once');
 
-  $hideInfoButton.disabled = false;
+  $hideAlwaysButton.disabled = false;
+  $hideOnceButton.disabled = false;
 
   const storedHideInfoValue = storage.getItem(STORAGE_HIDE_TEMP_BANNER);
   if (storedHideInfoValue) {
-    hideElement($infoBanner);
+    hideElement($feedbackBanner);
   }
 
-  $hideInfoButton.addEventListener('click', (event) => {
+  $hideAlwaysButton.addEventListener('click', (event) => {
     event.preventDefault();
-    hideElement($infoBanner);
+    hideElement($feedbackBanner);
     storage.setItem(STORAGE_HIDE_TEMP_BANNER, true);
+  });
+  $hideOnceButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    hideElement($feedbackBanner);
   });
 }

--- a/public/scripts/oldversion.js
+++ b/public/scripts/oldversion.js
@@ -1,0 +1,20 @@
+import { hideElement } from './dom-utils.js';
+import { STORAGE_HIDE_INFO_BANNER } from './storage.js';
+
+export default function initCopyButtons(document, storage) {
+  const $infoBanner = document.querySelector('.info-oldversion');
+  const $hideInfoButton = document.getElementById('hide-oldversion');
+
+  $hideInfoButton.disabled = false;
+
+  const storedHideInfoValue = storage.getItem(STORAGE_HIDE_INFO_BANNER);
+  if (storedHideInfoValue) {
+    hideElement($infoBanner);
+  }
+
+  $hideInfoButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    hideElement($infoBanner);
+    storage.setItem(STORAGE_HIDE_INFO_BANNER, true);
+  });
+}

--- a/public/scripts/oldversion.js
+++ b/public/scripts/oldversion.js
@@ -1,13 +1,13 @@
 import { hideElement } from './dom-utils.js';
-import { STORAGE_HIDE_INFO_BANNER } from './storage.js';
+import { STORAGE_HIDE_TEMP_BANNER } from './storage.js';
 
 export default function initCopyButtons(document, storage) {
-  const $infoBanner = document.querySelector('.info-oldversion');
-  const $hideInfoButton = document.getElementById('hide-oldversion');
+  const $infoBanner = document.querySelector('.banner-feedback');
+  const $hideInfoButton = document.getElementById('hide-feedback-banner');
 
   $hideInfoButton.disabled = false;
 
-  const storedHideInfoValue = storage.getItem(STORAGE_HIDE_INFO_BANNER);
+  const storedHideInfoValue = storage.getItem(STORAGE_HIDE_TEMP_BANNER);
   if (storedHideInfoValue) {
     hideElement($infoBanner);
   }
@@ -15,6 +15,6 @@ export default function initCopyButtons(document, storage) {
   $hideInfoButton.addEventListener('click', (event) => {
     event.preventDefault();
     hideElement($infoBanner);
-    storage.setItem(STORAGE_HIDE_INFO_BANNER, true);
+    storage.setItem(STORAGE_HIDE_TEMP_BANNER, true);
   });
 }

--- a/public/scripts/storage.js
+++ b/public/scripts/storage.js
@@ -1,5 +1,6 @@
 export const STORAGE_KEY_COLOR_SCHEME = 'preferred-color-scheme';
 export const STORAGE_KEY_ORDERING = 'preferred-ordering';
+export const STORAGE_HIDE_INFO_BANNER = 'info-banner';
 
 const mockStorage = {
   getItem() {},

--- a/public/scripts/storage.js
+++ b/public/scripts/storage.js
@@ -1,6 +1,6 @@
 export const STORAGE_KEY_COLOR_SCHEME = 'preferred-color-scheme';
 export const STORAGE_KEY_ORDERING = 'preferred-ordering';
-export const STORAGE_HIDE_INFO_BANNER = 'info-banner';
+export const STORAGE_HIDE_TEMP_BANNER = 'temporary-banner';
 
 const mockStorage = {
   getItem() {},

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -682,3 +682,32 @@ body.order-by-relevance .grid-item {
 .copy-button.copied.contrast-light::before {
   background-image: var(--dm-asset-svg-copied);
 }
+
+/* informative banner */
+
+.info-oldversion {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.8rem;
+  padding: 8px var(--side-offset);
+}
+
+.info-oldversion.hidden {
+  display: none;
+}
+
+.info-oldversion a,
+.info-oldversion button {
+  color: var(--color-link);
+  font-family: inherit;
+  font-size: inherit;
+}
+.info-oldversion a:focus,
+.info-oldversion a:hover,
+.info-oldversion button:focus,
+.info-oldversion button:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+.info-oldversion a:visited {
+  color: var(--color-link-visited);
+}

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -765,27 +765,27 @@ body.order-by-relevance .grid-item {
   width: 0;
 }
 
-/* informative banner */
+/* Temporary feedback banner */
 
-.info-oldversion {
+.banner-feedback {
   font-family: 'Roboto Mono', monospace;
   font-size: 0.8rem;
   padding: 8px var(--side-offset);
 }
 
-.info-oldversion a,
-.info-oldversion button {
+.banner-feedback a,
+.banner-feedback button {
   color: var(--color-link);
   font-family: inherit;
   font-size: inherit;
 }
-.info-oldversion a:focus,
-.info-oldversion a:hover,
-.info-oldversion button:focus,
-.info-oldversion button:hover {
+.banner-feedback a:focus,
+.banner-feedback a:hover,
+.banner-feedback button:focus,
+.banner-feedback button:hover {
   color: var(--color-link-hover);
   text-decoration: underline;
 }
-.info-oldversion a:visited {
+.banner-feedback a:visited {
   color: var(--color-link-visited);
 }

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -789,3 +789,7 @@ body.order-by-relevance .grid-item {
 .banner-feedback a:visited {
   color: var(--color-link-visited);
 }
+
+.banner__hide {
+  float: right;
+}


### PR DESCRIPTION
In preparation for testing the redesign with users. This adds a small bit if text to the top of the page that allows users to either **a)** provide feedback at https://github.com/simple-icons/simple-icons/discussions/4865, **b)** go back to [the current version of the website](https://simpleicons.org/), or **c)** hide the banner.

This banner will look like the following when you first visit the page:

![image](https://user-images.githubusercontent.com/3742559/105874627-15adac00-5ffd-11eb-8957-ecfd74ca7010.png)
