### PR TITLE
Increase unit test coverage of site scripts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests
-        run: npm run test
+        run: npm run test:all
       - name: Upload test screenshots
         uses: actions/upload-artifact@v2
         with:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,4 +4,5 @@
 git stash -q --keep-index
 npm run lint
 npm run build
+npm run test:unit
 git stash pop -q || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ The repository defines the following commands that can be used for development p
 | `npm run lint` | Lint the source code of the project. |
 | `npm run serve` | Serve the files in the `_site/` directory. |
 | `npm run serve:watch` | Run `build:watch` and `serve` in parallel. |
-| `npm run test` | Run the test suites for the website. |
+| `npm run test:all` | Run all unit & integration test suites. (**warning**: slow) |
+| `npm run test:unit` | Run all unit test suites. |
 
 ### Using Docker
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,6 @@ const TEST_ENV_OPTIONS = [TEST_ENV_ALL, TEST_ENV_UNIT];
 
 let bail = 0;
 let preset = undefined;
-let globals = {};
 let ignorePaths = ['/node_modules/'];
 
 switch (process.env.TEST_ENV) {
@@ -18,7 +17,6 @@ switch (process.env.TEST_ENV) {
 
     bail = 1; // Fail immediately to avoid running costly tests unnecessarily
     preset = 'jest-puppeteer';
-    globals.ARTIFACTS_DIR = path.resolve(__dirname, 'tests/_artifacts');
     break;
   case TEST_ENV_UNIT:
     ignorePaths.push('integration.test.js');
@@ -31,6 +29,8 @@ switch (process.env.TEST_ENV) {
 module.exports = {
   bail,
   preset,
-  globals,
+  globals: {
+    ARTIFACTS_DIR: path.resolve(__dirname, 'tests/_artifacts'),
+  },
   testPathIgnorePatterns: ignorePaths,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,36 @@
+const { execSync } = require('child_process');
 const path = require('path');
 
+const TEST_ENV_ALL = 'all';
+const TEST_ENV_UNIT = 'unit';
+const TEST_ENV_OPTIONS = [TEST_ENV_ALL, TEST_ENV_UNIT];
+
+let bail = 0;
+let preset = undefined;
+let globals = {};
+let ignorePaths = ['/node_modules/'];
+
+switch (process.env.TEST_ENV) {
+  case TEST_ENV_ALL:
+    console.info('building website for integration tests...');
+    execSync('npm run clean');
+    execSync('npm run build:dev');
+
+    bail = 1; // Fail immediately to avoid running costly tests unnecessarily
+    preset = 'jest-puppeteer';
+    globals.ARTIFACTS_DIR = path.resolve(__dirname, 'tests/_artifacts');
+    break;
+  case TEST_ENV_UNIT:
+    ignorePaths.push('integration.test.js');
+    break;
+  default:
+    console.info(`[ERROR] please set TEST_ENV to one of [${TEST_ENV_OPTIONS}]`);
+    process.exit(1);
+}
+
 module.exports = {
-  preset: 'jest-puppeteer',
-  globals: {
-    ARTIFACTS_DIR: path.resolve(__dirname, 'tests/_artifacts'),
-  },
+  bail,
+  preset,
+  globals,
+  testPathIgnorePatterns: ignorePaths,
 };

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "format": "prettier --write --single-quote --trailing-comma all .",
     "lint": "prettier --check --single-quote --trailing-comma all .",
     "postinstall": "is-ci || husky install",
-    "pretest": "npm run clean && npm run build:dev",
     "serve": "anywhere -p 8080 -d ./_site",
     "serve:watch": "run-p build:watch serve",
-    "test": "jest"
+    "test:all": "TEST_ENV=all jest",
+    "test:unit": "TEST_ENV=unit jest"
   },
   "dependencies": {
     "simple-icons": "4.9.0",

--- a/public/index.pug
+++ b/public/index.pug
@@ -27,7 +27,7 @@ html
     link(rel="mask-icon" href="https://simpleicons.org/images/logo.svg" color="#111111")
     link(rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&family=Roboto+Mono:wght@400;600&display=swap")
 
-  body(class="no-js")
+  body(class="no-js order-alphabetically")
     div(class="banner-feedback" role="banner")
       span #[a(href="https://github.com/simple-icons/simple-icons/discussions/4865" rel="noopener") Share your opinion of the redesign on GitHub] or #[a(href="https://simpleicons.org/" rel="noopener") Go to the old design]
       span(class="banner__hide") Hide this message #[button(id="hide-feedback-banner-once" disabled) Once] or #[button(id="hide-feedback-banner" disabled) Always]

--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -10,7 +10,7 @@ const CLASS_DARK_MODE = 'dark';
 const CLASS_LIGHT_MODE = 'light';
 
 export default function initColorScheme(document, storage) {
-  let activeColorScheme = null;
+  let activeColorScheme = DEFAULT_COLOR_SCHEME;
 
   const $body = document.querySelector('body');
   const $colorSchemeDark = document.getElementById('color-scheme-dark');
@@ -24,8 +24,6 @@ export default function initColorScheme(document, storage) {
   const storedColorScheme = storage.getItem(STORAGE_KEY_COLOR_SCHEME);
   if (storedColorScheme) {
     selectColorScheme(storedColorScheme);
-  } else {
-    selectColorScheme(DEFAULT_COLOR_SCHEME);
   }
 
   $colorSchemeDark.addEventListener('click', (event) => {

--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -9,9 +9,9 @@ const DEFAULT_COLOR_SCHEME = COLOR_SCHEME_SYSTEM;
 const CLASS_DARK_MODE = 'dark';
 const CLASS_LIGHT_MODE = 'light';
 
-let activeColorScheme = null;
-
 export default function initColorScheme(document, storage) {
+  let activeColorScheme = null;
+
   const $body = document.querySelector('body');
   const $colorSchemeDark = document.getElementById('color-scheme-dark');
   const $colorSchemeLight = document.getElementById('color-scheme-light');
@@ -45,16 +45,18 @@ export default function initColorScheme(document, storage) {
   });
 
   function selectColorScheme(selected) {
-    if (selected !== activeColorScheme) {
-      if (selected === COLOR_SCHEME_DARK) {
-        $body.classList.add(CLASS_DARK_MODE);
-        $body.classList.remove(CLASS_LIGHT_MODE);
-      } else if (selected === COLOR_SCHEME_LIGHT) {
-        $body.classList.add(CLASS_LIGHT_MODE);
-        $body.classList.remove(CLASS_DARK_MODE);
-      } else {
-        $body.classList.remove(CLASS_DARK_MODE, CLASS_LIGHT_MODE);
-      }
+    if (selected === activeColorScheme) {
+      return;
+    }
+
+    if (selected === COLOR_SCHEME_DARK) {
+      $body.classList.add(CLASS_DARK_MODE);
+      $body.classList.remove(CLASS_LIGHT_MODE);
+    } else if (selected === COLOR_SCHEME_LIGHT) {
+      $body.classList.add(CLASS_LIGHT_MODE);
+      $body.classList.remove(CLASS_DARK_MODE);
+    } else {
+      $body.classList.remove(CLASS_DARK_MODE, CLASS_LIGHT_MODE);
     }
 
     storage.setItem(STORAGE_KEY_COLOR_SCHEME, selected);

--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -9,7 +9,7 @@ const DEFAULT_COLOR_SCHEME = COLOR_SCHEME_SYSTEM;
 const CLASS_DARK_MODE = 'dark';
 const CLASS_LIGHT_MODE = 'light';
 
-let activeColorScheme = DEFAULT_COLOR_SCHEME;
+let activeColorScheme = null;
 
 export default function initColorScheme(document, storage) {
   const $body = document.querySelector('body');
@@ -30,35 +30,31 @@ export default function initColorScheme(document, storage) {
 
   $colorSchemeDark.addEventListener('click', (event) => {
     event.preventDefault();
-    if (activeColorScheme != COLOR_SCHEME_DARK) {
-      selectColorScheme(COLOR_SCHEME_DARK);
-      $colorSchemeDark.blur();
-    }
+    selectColorScheme(COLOR_SCHEME_DARK);
+    $colorSchemeDark.blur();
   });
   $colorSchemeLight.addEventListener('click', (event) => {
     event.preventDefault();
-    if (activeColorScheme != COLOR_SCHEME_LIGHT) {
-      selectColorScheme(COLOR_SCHEME_LIGHT);
-      $colorSchemeLight.blur();
-    }
+    selectColorScheme(COLOR_SCHEME_LIGHT);
+    $colorSchemeLight.blur();
   });
   $colorSchemeSystem.addEventListener('click', (event) => {
     event.preventDefault();
-    if (activeColorScheme != COLOR_SCHEME_SYSTEM) {
-      selectColorScheme(COLOR_SCHEME_SYSTEM);
-      $colorSchemeSystem.blur();
-    }
+    selectColorScheme(COLOR_SCHEME_SYSTEM);
+    $colorSchemeSystem.blur();
   });
 
   function selectColorScheme(selected) {
-    if (selected === COLOR_SCHEME_DARK) {
-      $body.classList.add(CLASS_DARK_MODE);
-      $body.classList.remove(CLASS_LIGHT_MODE);
-    } else if (selected === COLOR_SCHEME_LIGHT) {
-      $body.classList.add(CLASS_LIGHT_MODE);
-      $body.classList.remove(CLASS_DARK_MODE);
-    } else {
-      $body.classList.remove(CLASS_DARK_MODE, CLASS_LIGHT_MODE);
+    if (selected !== activeColorScheme) {
+      if (selected === COLOR_SCHEME_DARK) {
+        $body.classList.add(CLASS_DARK_MODE);
+        $body.classList.remove(CLASS_LIGHT_MODE);
+      } else if (selected === COLOR_SCHEME_LIGHT) {
+        $body.classList.add(CLASS_LIGHT_MODE);
+        $body.classList.remove(CLASS_DARK_MODE);
+      } else {
+        $body.classList.remove(CLASS_DARK_MODE, CLASS_LIGHT_MODE);
+      }
     }
 
     storage.setItem(STORAGE_KEY_COLOR_SCHEME, selected);

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -1,11 +1,13 @@
 import '../stylesheet.css';
 
+import * as domUtils from './dom-utils.js';
+import newStorage from './storage.js';
+
 import initCopyButtons from './copy.js';
 import initColorScheme from './color-scheme.js';
 import initOrdering from './ordering.js';
 import initSearch from './search.js';
 import initFeedbackRequest from './feedback-request.js';
-import newStorage from './storage.js';
 
 document.body.classList.remove('no-js');
 
@@ -13,5 +15,5 @@ const storage = newStorage(localStorage);
 initColorScheme(document, storage);
 initCopyButtons(document, navigator);
 const orderingControls = initOrdering(document, storage);
-initSearch(window.history, document, orderingControls);
+initSearch(window.history, document, orderingControls, domUtils);
 initFeedbackRequest(document, storage);

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -10,10 +10,10 @@ const CLASS_ORDER_ALPHABETICALLY = 'order-alphabetically';
 const CLASS_ORDER_BY_COLOR = 'order-by-color';
 const CLASS_ORDER_BY_RELEVANCE = 'order-by-relevance';
 
-let activeOrdering = DEFAULT_ORDERING;
-let preferredOrdering = DEFAULT_ORDERING;
-
 export default function initOrdering(document, storage) {
+  let activeOrdering = null;
+  let preferredOrdering = null;
+
   const $body = document.querySelector('body');
   const $orderAlphabetically = document.getElementById('order-alpha');
   const $orderByColor = document.getElementById('order-color');
@@ -32,24 +32,18 @@ export default function initOrdering(document, storage) {
 
   $orderAlphabetically.addEventListener('click', (event) => {
     event.preventDefault();
-    if (activeOrdering != ORDER_ALPHABETICALLY) {
-      selectOrdering(ORDER_ALPHABETICALLY);
-      $orderAlphabetically.blur();
-    }
+    selectOrdering(ORDER_ALPHABETICALLY);
+    $orderAlphabetically.blur();
   });
   $orderByColor.addEventListener('click', (event) => {
     event.preventDefault();
-    if (activeOrdering != ORDER_BY_COLOR) {
-      selectOrdering(ORDER_BY_COLOR);
-      $orderByColor.blur();
-    }
+    selectOrdering(ORDER_BY_COLOR);
+    $orderByColor.blur();
   });
   $orderByRelevance.addEventListener('click', (event) => {
     event.preventDefault();
-    if (activeOrdering != ORDER_BY_RELEVANCE) {
-      selectOrdering(ORDER_BY_RELEVANCE);
-      $orderByRelevance.blur();
-    }
+    selectOrdering(ORDER_BY_RELEVANCE);
+    $orderByRelevance.blur();
   });
 
   function currentOrderingIs(value) {
@@ -57,6 +51,10 @@ export default function initOrdering(document, storage) {
   }
 
   function selectOrdering(selected) {
+    if (selected === activeOrdering) {
+      return;
+    }
+
     $body.classList.remove(
       CLASS_ORDER_ALPHABETICALLY,
       CLASS_ORDER_BY_COLOR,

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -11,8 +11,8 @@ const CLASS_ORDER_BY_COLOR = 'order-by-color';
 const CLASS_ORDER_BY_RELEVANCE = 'order-by-relevance';
 
 export default function initOrdering(document, storage) {
-  let activeOrdering = null;
-  let preferredOrdering = null;
+  let activeOrdering = DEFAULT_ORDERING;
+  let preferredOrdering = DEFAULT_ORDERING;
 
   const $body = document.querySelector('body');
   const $orderAlphabetically = document.getElementById('order-alpha');
@@ -26,8 +26,6 @@ export default function initOrdering(document, storage) {
   const storedOrdering = storage.getItem(STORAGE_KEY_ORDERING);
   if (storedOrdering) {
     selectOrdering(storedOrdering);
-  } else {
-    selectOrdering(DEFAULT_ORDERING);
   }
 
   $orderAlphabetically.addEventListener('click', (event) => {

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -1,12 +1,9 @@
-import { hideElement, showElement } from './dom-utils.js';
 import { ORDER_BY_RELEVANCE } from './ordering.js';
 import { decodeURIComponent, debounce, normalizeSearchTerm } from './utils.js';
 
 const QUERY_PARAMETER = 'q';
 
-let activeQuery = '';
-
-function getQueryFromParameter(parameter) {
+function getQueryFromParameter(location, parameter) {
   const expr = new RegExp(`[\\?&]${parameter}=([^&#]*)`);
   const results = expr.exec(location.search);
   if (results !== null) {
@@ -45,12 +42,14 @@ function setSearchQueryInURL(history, path, query) {
   }
 }
 
-export default function initSearch(history, document, ordering) {
+export default function initSearch(history, document, ordering, domUtils) {
+  let activeQuery = '';
+
   const $searchInput = document.getElementById('search-input');
   const $searchClear = document.getElementById('search-clear');
   const $orderByRelevance = document.getElementById('order-relevance');
   const $gridItemIfEmpty = document.querySelector('.grid-item--if-empty');
-  const $adSpace = document.querySelector('#carbonads');
+  const $adSpace = document.getElementById('carbonads');
   const $icons = document.querySelectorAll('.grid-item[data-brand]');
 
   $searchInput.disabled = false;
@@ -71,7 +70,7 @@ export default function initSearch(history, document, ordering) {
   });
 
   // Load search query if present
-  const query = getQueryFromParameter(QUERY_PARAMETER);
+  const query = getQueryFromParameter(document.location, QUERY_PARAMETER);
   if (query) {
     $searchInput.value = query;
     search(query);
@@ -81,16 +80,16 @@ export default function initSearch(history, document, ordering) {
     setSearchQueryInURL(history, document.location.pathname, rawQuery);
     const query = normalizeSearchTerm(rawQuery);
     if (query !== '') {
-      showElement($searchClear);
-      showElement($orderByRelevance);
-      hideElement($adSpace);
+      domUtils.showElement($searchClear);
+      domUtils.showElement($orderByRelevance);
+      domUtils.hideElement($adSpace);
       if (activeQuery === '') {
         ordering.selectOrdering(ORDER_BY_RELEVANCE);
       }
     } else {
-      hideElement($searchClear);
-      hideElement($orderByRelevance);
-      showElement($adSpace);
+      domUtils.hideElement($searchClear);
+      domUtils.hideElement($orderByRelevance);
+      domUtils.showElement($adSpace);
       if (ordering.currentOrderingIs(ORDER_BY_RELEVANCE)) {
         ordering.resetOrdering();
       }
@@ -102,18 +101,18 @@ export default function initSearch(history, document, ordering) {
       const score = getScore(query, brandName);
       if (score < 0) {
         $icon.style.removeProperty('--order-relevance');
-        hideElement($icon);
+        domUtils.hideElement($icon);
       } else {
         $icon.style.setProperty('--order-relevance', score);
-        showElement($icon);
+        domUtils.showElement($icon);
         noResults = false;
       }
     });
 
     if (noResults) {
-      showElement($gridItemIfEmpty);
+      domUtils.showElement($gridItemIfEmpty);
     } else {
-      hideElement($gridItemIfEmpty);
+      domUtils.hideElement($gridItemIfEmpty);
     }
 
     activeQuery = query;

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -9,23 +9,14 @@ const initColorScheme = require('../public/scripts/color-scheme.js').default;
 const { STORAGE_KEY_COLOR_SCHEME } = require('../public/scripts/storage.js');
 
 describe('Color scheme', () => {
-  let $body;
-
   beforeEach(() => {
     document.__resetAllMocks();
     localStorage.__resetAllMocks();
-
-    $body = newElementMock('body');
-    document.querySelector.mockImplementation((query) => {
-      if (query === 'body') {
-        return $body;
-      }
-
-      return newElementMock(query);
-    });
   });
 
   it('gets the #color-scheme-dark button', () => {
+    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
+
     const eventListeners = new Map();
 
     let $colorSchemeDark = newElementMock('#color-scheme-dark');
@@ -49,6 +40,8 @@ describe('Color scheme', () => {
       expect.any(Function),
     );
 
+    localStorage.setItem.mockClear();
+
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
@@ -61,6 +54,8 @@ describe('Color scheme', () => {
   });
 
   it('gets the #color-scheme-light button', () => {
+    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
+
     const eventListeners = new Map();
 
     let $colorSchemeLight = newElementMock('#color-scheme-light');
@@ -84,6 +79,8 @@ describe('Color scheme', () => {
       expect.any(Function),
     );
 
+    localStorage.setItem.mockClear();
+
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
@@ -96,6 +93,8 @@ describe('Color scheme', () => {
   });
 
   it('gets the #color-scheme-system button', () => {
+    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
+
     const eventListeners = new Map();
 
     let $colorSchemeSystem = newElementMock('#color-scheme-system');
@@ -119,6 +118,8 @@ describe('Color scheme', () => {
       expect.any(Function),
     );
 
+    localStorage.setItem.mockClear();
+
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
@@ -132,6 +133,7 @@ describe('Color scheme', () => {
 
   it('uses the system color scheme if no value is stored', () => {
     initColorScheme(document, localStorage);
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'system',
@@ -143,8 +145,9 @@ describe('Color scheme', () => {
     localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
     initColorScheme(document, localStorage);
-    expect($body.classList.add).toHaveBeenCalledWith('dark');
-    expect($body.classList.remove).toHaveBeenCalledWith('light');
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
+    expect(document.$body.classList.add).toHaveBeenCalledWith('dark');
+    expect(document.$body.classList.remove).toHaveBeenCalledWith('light');
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       storedValue,
@@ -156,8 +159,9 @@ describe('Color scheme', () => {
     localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
     initColorScheme(document, localStorage);
-    expect($body.classList.add).toHaveBeenCalledWith('light');
-    expect($body.classList.remove).toHaveBeenCalledWith('dark');
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
+    expect(document.$body.classList.add).toHaveBeenCalledWith('light');
+    expect(document.$body.classList.remove).toHaveBeenCalledWith('dark');
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       storedValue,
@@ -169,7 +173,11 @@ describe('Color scheme', () => {
     localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
     initColorScheme(document, localStorage);
-    expect($body.classList.remove).toHaveBeenCalledWith('dark', 'light');
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
+    expect(document.$body.classList.remove).toHaveBeenCalledWith(
+      'dark',
+      'light',
+    );
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       storedValue,

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -15,7 +15,7 @@ describe('Color scheme', () => {
   });
 
   it('gets the #color-scheme-dark button', () => {
-    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
+    localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
 
     const eventListeners = new Map();
 
@@ -54,7 +54,7 @@ describe('Color scheme', () => {
   });
 
   it('gets the #color-scheme-light button', () => {
-    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
+    localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
 
     const eventListeners = new Map();
 
@@ -93,7 +93,7 @@ describe('Color scheme', () => {
   });
 
   it('gets the #color-scheme-system button', () => {
-    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
+    localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, 'unknown');
 
     const eventListeners = new Map();
 
@@ -134,20 +134,18 @@ describe('Color scheme', () => {
   it('uses the system color scheme if no value is stored', () => {
     initColorScheme(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      STORAGE_KEY_COLOR_SCHEME,
-      'system',
-    );
+    expect(localStorage.setItem).not.toHaveBeenCalledWith();
   });
 
   it('uses the stored value "dark"', () => {
     const storedValue = 'dark';
-    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
+    localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
     initColorScheme(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(document.$body.classList.add).toHaveBeenCalledWith('dark');
     expect(document.$body.classList.remove).toHaveBeenCalledWith('light');
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       storedValue,
@@ -156,12 +154,13 @@ describe('Color scheme', () => {
 
   it('uses the stored value "light"', () => {
     const storedValue = 'light';
-    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
+    localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
     initColorScheme(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(document.$body.classList.add).toHaveBeenCalledWith('light');
     expect(document.$body.classList.remove).toHaveBeenCalledWith('dark');
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       storedValue,
@@ -170,17 +169,10 @@ describe('Color scheme', () => {
 
   it('uses the stored value "system"', () => {
     const storedValue = 'system';
-    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
+    localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
     initColorScheme(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
-    expect(document.$body.classList.remove).toHaveBeenCalledWith(
-      'dark',
-      'light',
-    );
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      STORAGE_KEY_COLOR_SCHEME,
-      storedValue,
-    );
+    expect(localStorage.setItem).not.toHaveBeenCalledWith();
   });
 });

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -19,7 +19,7 @@ describe('Color scheme', () => {
 
     const eventListeners = new Map();
 
-    let $colorSchemeDark = newElementMock('#color-scheme-dark');
+    const $colorSchemeDark = newElementMock('#color-scheme-dark');
     $colorSchemeDark.addEventListener.mockImplementation((name, fn) => {
       eventListeners.set(name, fn);
     });
@@ -58,7 +58,7 @@ describe('Color scheme', () => {
 
     const eventListeners = new Map();
 
-    let $colorSchemeLight = newElementMock('#color-scheme-light');
+    const $colorSchemeLight = newElementMock('#color-scheme-light');
     $colorSchemeLight.addEventListener.mockImplementation((name, fn) => {
       eventListeners.set(name, fn);
     });
@@ -97,7 +97,7 @@ describe('Color scheme', () => {
 
     const eventListeners = new Map();
 
-    let $colorSchemeSystem = newElementMock('#color-scheme-system');
+    const $colorSchemeSystem = newElementMock('#color-scheme-system');
     $colorSchemeSystem.addEventListener.mockImplementation((name, fn) => {
       eventListeners.set(name, fn);
     });

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -1,0 +1,61 @@
+const initColorScheme = require('../public/scripts/color-scheme.js').default;
+const { STORAGE_KEY_COLOR_SCHEME } = require('../public/scripts/storage.js');
+
+function newElementMock() {
+  return {
+    addEventListener: jest.fn().mockName('$el.addEventListener'),
+    classList: {
+      add: jest.fn().mockName('$el.classList.add'),
+      remove: jest.fn().mockName('$el.classList.remove'),
+    },
+  };
+}
+
+const documentMock = {
+  getElementById: jest
+    .fn()
+    .mockImplementation(newElementMock)
+    .mockName('document.getElementById'),
+  querySelector: jest
+    .fn()
+    .mockImplementation(newElementMock)
+    .mockName('document.querySelector'),
+  _clearAllMocks: function () {
+    this.querySelector.mockClear();
+    this.getElementById.mockClear();
+  },
+};
+
+const localStorageMock = {
+  getItem: jest.fn().mockName('localStorage.getItem'),
+  setItem: jest.fn().mockName('localStorage.setItem'),
+  _clearAllMocks: function () {
+    this.getItem.mockClear();
+    this.setItem.mockClear();
+  },
+};
+
+describe('DOM', () => {
+  beforeEach(() => documentMock._clearAllMocks());
+
+  it('gets elements from the DOM by id', () => {
+    initColorScheme(documentMock, localStorageMock);
+    expect(documentMock.getElementById).toHaveBeenCalled();
+  });
+
+  it('gets elements from the DOM by CSS selector', () => {
+    initColorScheme(documentMock, localStorageMock);
+    expect(documentMock.querySelector).toHaveBeenCalled();
+  });
+});
+
+describe('localStorage', () => {
+  beforeEach(() => localStorageMock._clearAllMocks());
+
+  it('checks if a value is stored for the color scheme', () => {
+    initColorScheme(documentMock, localStorageMock);
+    expect(localStorageMock.getItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+    );
+  });
+});

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -1,30 +1,178 @@
-const { documentMock } = require('./mocks/dom.mock.js');
-const { localStorageMock } = require('./mocks/local-storage.mock.js');
+const {
+  document,
+  newElementMock,
+  newEventMock,
+} = require('./mocks/dom.mock.js');
+const { localStorage } = require('./mocks/local-storage.mock.js');
 
 const initColorScheme = require('../public/scripts/color-scheme.js').default;
 const { STORAGE_KEY_COLOR_SCHEME } = require('../public/scripts/storage.js');
 
-describe('DOM', () => {
-  beforeEach(() => documentMock.__clearAllMocks());
+describe('Color scheme', () => {
+  let $body;
 
-  it('gets elements from the DOM by id', () => {
-    initColorScheme(documentMock, localStorageMock);
-    expect(documentMock.getElementById).toHaveBeenCalled();
+  beforeEach(() => {
+    document.__resetAllMocks();
+    localStorage.__resetAllMocks();
+
+    $body = newElementMock('body');
+    document.querySelector.mockImplementation((query) => {
+      if (query === 'body') {
+        return $body;
+      }
+
+      return newElementMock(query);
+    });
   });
 
-  it('gets elements from the DOM by CSS selector', () => {
-    initColorScheme(documentMock, localStorageMock);
-    expect(documentMock.querySelector).toHaveBeenCalled();
-  });
-});
+  it('gets the #color-scheme-dark button', () => {
+    const eventListeners = new Map();
 
-describe('localStorage', () => {
-  beforeEach(() => localStorageMock.__clearAllMocks());
+    let $colorSchemeDark = newElementMock('#color-scheme-dark');
+    $colorSchemeDark.addEventListener.mockImplementation((name, fn) => {
+      eventListeners.set(name, fn);
+    });
 
-  it('checks if a value is stored for the color scheme', () => {
-    initColorScheme(documentMock, localStorageMock);
-    expect(localStorageMock.getItem).toHaveBeenCalledWith(
+    document.getElementById.mockImplementation((query) => {
+      if (query === 'color-scheme-dark') {
+        return $colorSchemeDark;
+      }
+
+      return newElementMock(query);
+    });
+
+    initColorScheme(document, localStorage);
+    expect(document.getElementById).toHaveBeenCalledWith('color-scheme-dark');
+    expect($colorSchemeDark.disabled).toBe(false);
+    expect($colorSchemeDark.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+
+    const clickListener = eventListeners.get('click');
+    const event = newEventMock();
+    clickListener(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect($colorSchemeDark.blur).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
+      'dark',
+    );
+  });
+
+  it('gets the #color-scheme-light button', () => {
+    const eventListeners = new Map();
+
+    let $colorSchemeLight = newElementMock('#color-scheme-light');
+    $colorSchemeLight.addEventListener.mockImplementation((name, fn) => {
+      eventListeners.set(name, fn);
+    });
+
+    document.getElementById.mockImplementation((query) => {
+      if (query === 'color-scheme-light') {
+        return $colorSchemeLight;
+      }
+
+      return newElementMock(query);
+    });
+
+    initColorScheme(document, localStorage);
+    expect(document.getElementById).toHaveBeenCalledWith('color-scheme-light');
+    expect($colorSchemeLight.disabled).toBe(false);
+    expect($colorSchemeLight.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+
+    const clickListener = eventListeners.get('click');
+    const event = newEventMock();
+    clickListener(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect($colorSchemeLight.blur).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+      'light',
+    );
+  });
+
+  it('gets the #color-scheme-system button', () => {
+    const eventListeners = new Map();
+
+    let $colorSchemeSystem = newElementMock('#color-scheme-system');
+    $colorSchemeSystem.addEventListener.mockImplementation((name, fn) => {
+      eventListeners.set(name, fn);
+    });
+
+    document.getElementById.mockImplementation((query) => {
+      if (query === 'color-scheme-system') {
+        return $colorSchemeSystem;
+      }
+
+      return newElementMock(query);
+    });
+
+    initColorScheme(document, localStorage);
+    expect(document.getElementById).toHaveBeenCalledWith('color-scheme-system');
+    expect($colorSchemeSystem.disabled).toBe(false);
+    expect($colorSchemeSystem.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+
+    const clickListener = eventListeners.get('click');
+    const event = newEventMock();
+    clickListener(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect($colorSchemeSystem.blur).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+      'system',
+    );
+  });
+
+  it('uses the system color scheme if no value is stored', () => {
+    initColorScheme(document, localStorage);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+      'system',
+    );
+  });
+
+  it('uses the stored value "dark"', () => {
+    const storedValue = 'dark';
+    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
+
+    initColorScheme(document, localStorage);
+    expect($body.classList.add).toHaveBeenCalledWith('dark');
+    expect($body.classList.remove).toHaveBeenCalledWith('light');
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+      storedValue,
+    );
+  });
+
+  it('uses the stored value "light"', () => {
+    const storedValue = 'light';
+    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
+
+    initColorScheme(document, localStorage);
+    expect($body.classList.add).toHaveBeenCalledWith('light');
+    expect($body.classList.remove).toHaveBeenCalledWith('dark');
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+      storedValue,
+    );
+  });
+
+  it('uses the stored value "system"', () => {
+    const storedValue = 'system';
+    localStorage.__storedValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
+
+    initColorScheme(document, localStorage);
+    expect($body.classList.remove).toHaveBeenCalledWith('dark', 'light');
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_COLOR_SCHEME,
+      storedValue,
     );
   });
 });

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -1,42 +1,11 @@
+const { documentMock } = require('./mocks/dom.mock.js');
+const { localStorageMock } = require('./mocks/local-storage.mock.js');
+
 const initColorScheme = require('../public/scripts/color-scheme.js').default;
 const { STORAGE_KEY_COLOR_SCHEME } = require('../public/scripts/storage.js');
 
-function newElementMock() {
-  return {
-    addEventListener: jest.fn().mockName('$el.addEventListener'),
-    classList: {
-      add: jest.fn().mockName('$el.classList.add'),
-      remove: jest.fn().mockName('$el.classList.remove'),
-    },
-  };
-}
-
-const documentMock = {
-  getElementById: jest
-    .fn()
-    .mockImplementation(newElementMock)
-    .mockName('document.getElementById'),
-  querySelector: jest
-    .fn()
-    .mockImplementation(newElementMock)
-    .mockName('document.querySelector'),
-  _clearAllMocks: function () {
-    this.querySelector.mockClear();
-    this.getElementById.mockClear();
-  },
-};
-
-const localStorageMock = {
-  getItem: jest.fn().mockName('localStorage.getItem'),
-  setItem: jest.fn().mockName('localStorage.setItem'),
-  _clearAllMocks: function () {
-    this.getItem.mockClear();
-    this.setItem.mockClear();
-  },
-};
-
 describe('DOM', () => {
-  beforeEach(() => documentMock._clearAllMocks());
+  beforeEach(() => documentMock.__clearAllMocks());
 
   it('gets elements from the DOM by id', () => {
     initColorScheme(documentMock, localStorageMock);
@@ -50,7 +19,7 @@ describe('DOM', () => {
 });
 
 describe('localStorage', () => {
-  beforeEach(() => localStorageMock._clearAllMocks());
+  beforeEach(() => localStorageMock.__clearAllMocks());
 
   it('checks if a value is stored for the color scheme', () => {
     initColorScheme(documentMock, localStorageMock);

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -7,7 +7,7 @@ const { navigator } = require('./mocks/navigator.mock.js');
 
 const initCopyButtons = require('../public/scripts/copy.js').default;
 
-describe('DOM', () => {
+describe('Copy', () => {
   beforeEach(() => {
     document.__resetAllMocks();
     navigator.__resetAllMocks();

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -1,0 +1,24 @@
+const { documentMock } = require('./mocks/dom.mock.js');
+const { navigatorMock } = require('./mocks/navigator.mock.js');
+
+const initCopyButtons = require('../public/scripts/copy.js').default;
+
+describe('DOM', () => {
+  beforeEach(() => documentMock.__clearAllMocks());
+
+  it('gets elements from the DOM by id', () => {
+    initCopyButtons(documentMock, navigatorMock);
+    expect(documentMock.getElementById).toHaveBeenCalled();
+  });
+
+  it('gets elements from the DOM by CSS selector', () => {
+    initCopyButtons(documentMock, navigatorMock);
+    expect(documentMock.querySelectorAll).toHaveBeenCalled();
+  });
+});
+
+describe('navigator', () => {
+  beforeEach(() => navigatorMock.__clearAllMocks());
+
+  it.todo('does something...');
+});

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -1,24 +1,24 @@
-const { documentMock } = require('./mocks/dom.mock.js');
-const { navigatorMock } = require('./mocks/navigator.mock.js');
+const { document } = require('./mocks/dom.mock.js');
+const { navigator } = require('./mocks/navigator.mock.js');
 
 const initCopyButtons = require('../public/scripts/copy.js').default;
 
 describe('DOM', () => {
-  beforeEach(() => documentMock.__clearAllMocks());
+  beforeEach(() => document.__resetAllMocks());
 
   it('gets elements from the DOM by id', () => {
-    initCopyButtons(documentMock, navigatorMock);
-    expect(documentMock.getElementById).toHaveBeenCalled();
+    initCopyButtons(document, navigator);
+    expect(document.getElementById).toHaveBeenCalled();
   });
 
   it('gets elements from the DOM by CSS selector', () => {
-    initCopyButtons(documentMock, navigatorMock);
-    expect(documentMock.querySelectorAll).toHaveBeenCalled();
+    initCopyButtons(document, navigator);
+    expect(document.querySelectorAll).toHaveBeenCalled();
   });
 });
 
 describe('navigator', () => {
-  beforeEach(() => navigatorMock.__clearAllMocks());
+  beforeEach(() => navigator.__resetAllMocks());
 
   it.todo('does something...');
 });

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -1,24 +1,117 @@
-const { document } = require('./mocks/dom.mock.js');
+const {
+  document,
+  newElementMock,
+  newEventMock,
+} = require('./mocks/dom.mock.js');
 const { navigator } = require('./mocks/navigator.mock.js');
 
 const initCopyButtons = require('../public/scripts/copy.js').default;
 
 describe('DOM', () => {
-  beforeEach(() => document.__resetAllMocks());
-
-  it('gets elements from the DOM by id', () => {
-    initCopyButtons(document, navigator);
-    expect(document.getElementById).toHaveBeenCalled();
+  beforeEach(() => {
+    document.__resetAllMocks();
+    navigator.__resetAllMocks();
   });
 
-  it('gets elements from the DOM by CSS selector', () => {
+  it('gets the #copy-input button', () => {
     initCopyButtons(document, navigator);
-    expect(document.querySelectorAll).toHaveBeenCalled();
+    expect(document.getElementById).toHaveBeenCalledWith('copy-input');
   });
-});
 
-describe('navigator', () => {
-  beforeEach(() => navigator.__resetAllMocks());
+  it('gets grid item color buttons', () => {
+    const eventListeners = new Map();
+    const $colorButtons = [
+      newElementMock('color button 1', { innerHTML: '#000FFF' }),
+      newElementMock('color button 2', { innerHTML: '#FFF000' }),
+    ];
 
-  it.todo('does something...');
+    for (const $colorButton of $colorButtons) {
+      const buttonEventListeners = new Map();
+      eventListeners.set($colorButton, buttonEventListeners);
+      $colorButton.addEventListener.mockImplementation((name, fn) => {
+        buttonEventListeners.set(name, fn);
+      });
+    }
+
+    document.querySelectorAll.mockImplementation((query) => {
+      if (query === '.grid-item__color') {
+        return $colorButtons;
+      }
+
+      return [];
+    });
+
+    initCopyButtons(document, navigator);
+    for (const $colorButton of $colorButtons) {
+      const buttonEventListeners = eventListeners.get($colorButton);
+
+      expect($colorButton.removeAttribute).toHaveBeenCalledWith('disabled');
+      expect($colorButton.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function),
+      );
+
+      const clickListener = buttonEventListeners.get('click');
+      const event = newEventMock();
+      clickListener(event);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect($colorButton.blur).toHaveBeenCalledTimes(1);
+      expect($colorButton.classList.add).toHaveBeenCalledWith('copied');
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        $colorButton.innerHTML,
+      );
+    }
+  });
+
+  it('gets grid item copy SVG source buttons', () => {
+    const eventListeners = new Map();
+    const $svgButtons = [
+      newElementMock('preview button 1', { parentNode: true }),
+      newElementMock('preview button 2', { parentNode: true }),
+    ];
+
+    for (const $svgButton of $svgButtons) {
+      const buttonEventListeners = new Map();
+      eventListeners.set($svgButton, buttonEventListeners);
+      $svgButton.addEventListener.mockImplementation((name, fn) => {
+        buttonEventListeners.set(name, fn);
+      });
+    }
+
+    document.querySelectorAll.mockImplementation((query) => {
+      if (query === '.grid-item__preview') {
+        return $svgButtons;
+      }
+
+      return [];
+    });
+
+    initCopyButtons(document, navigator);
+    for (const $svgButton of $svgButtons) {
+      const buttonEventListeners = eventListeners.get($svgButton);
+
+      const $svg = newElementMock('svg');
+      $svg.outerHTML = `<svg>${$svgButton.__name}</svg>`;
+
+      const $parent = $svgButton.parentNode;
+      $parent.querySelector.mockReturnValue($svg);
+
+      expect($svgButton.removeAttribute).toHaveBeenCalledWith('disabled');
+      expect($svgButton.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function),
+      );
+
+      const clickListener = buttonEventListeners.get('click');
+      const event = newEventMock();
+      clickListener(event);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect($svgButton.blur).toHaveBeenCalledTimes(1);
+      expect($svgButton.classList.add).toHaveBeenCalledWith('copied');
+      expect($parent.querySelector).toHaveBeenCalledWith('svg');
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        $svg.outerHTML,
+      );
+    }
+  });
 });

--- a/tests/mocks/dom-utils.mock.js
+++ b/tests/mocks/dom-utils.mock.js
@@ -1,0 +1,10 @@
+export const domUtils = {
+  hideElement: jest.fn().mockName('domUtils.hideElement'),
+  showElement: jest.fn().mockName('domUtils.showElement'),
+
+  // Utility to quickly clear the entire dom-utils mock.
+  __resetAllMocks: function () {
+    this.hideElement.mockReset();
+    this.showElement.mockReset();
+  },
+};

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -1,10 +1,11 @@
-export function newElementMock() {
+export function newElementMock(elName) {
   return {
-    addEventListener: jest.fn().mockName('$el.addEventListener'),
+    addEventListener: jest.fn().mockName(`${elName}.addEventListener`),
     classList: {
-      add: jest.fn().mockName('$el.classList.add'),
-      remove: jest.fn().mockName('$el.classList.remove'),
+      add: jest.fn().mockName(`${elName}.classList.add`),
+      remove: jest.fn().mockName(`${elName}.classList.remove`),
     },
+    removeAttribute: jest.fn().mockName(`${elName}.removeAttribute`),
   };
 }
 
@@ -17,10 +18,17 @@ export const documentMock = {
     .fn()
     .mockImplementation(newElementMock)
     .mockName('document.querySelector'),
+  querySelectorAll: jest
+    .fn()
+    .mockImplementation((elName) => {
+      return [newElementMock(`${elName}-0`), newElementMock(`${elName}-0`)];
+    })
+    .mockName('document.querySelectorAll'),
 
   // Utility to quickly clear the entire document mock.
   __clearAllMocks: function () {
     this.querySelector.mockClear();
     this.getElementById.mockClear();
+    this.querySelectorAll.mockClear();
   },
 };

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -27,7 +27,8 @@ export const document = {
   },
 };
 
-export function newElementMock(elName) {
+export function newElementMock(elName, opts) {
+  opts = opts || {};
   return {
     addEventListener: jest.fn().mockName(`${elName}.addEventListener`),
     blur: jest.fn().mockName(`${elName}.blur`),
@@ -36,6 +37,16 @@ export function newElementMock(elName) {
       remove: jest.fn().mockName(`${elName}.classList.remove`),
     },
     removeAttribute: jest.fn().mockName(`${elName}.removeAttribute`),
+    querySelector: jest.fn().mockName(`${elName}.querySelector`),
+
+    // Values
+    innerHTML: opts.innerHTML || '',
+    parentNode: opts.parentNode
+      ? newElementMock(`${elName} parent`, { parentNode: false })
+      : null,
+
+    // Utility
+    __name: elName,
   };
 }
 

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -1,0 +1,26 @@
+export function newElementMock() {
+  return {
+    addEventListener: jest.fn().mockName('$el.addEventListener'),
+    classList: {
+      add: jest.fn().mockName('$el.classList.add'),
+      remove: jest.fn().mockName('$el.classList.remove'),
+    },
+  };
+}
+
+export const documentMock = {
+  getElementById: jest
+    .fn()
+    .mockImplementation(newElementMock)
+    .mockName('document.getElementById'),
+  querySelector: jest
+    .fn()
+    .mockImplementation(newElementMock)
+    .mockName('document.querySelector'),
+
+  // Utility to quickly clear the entire document mock.
+  __clearAllMocks: function () {
+    this.querySelector.mockClear();
+    this.getElementById.mockClear();
+  },
+};

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -3,25 +3,26 @@ function newElementsMocks(elName) {
 }
 
 export const document = {
-  getElementById: jest
-    .fn()
-    .mockImplementation(newElementMock)
-    .mockName('document.getElementById'),
-  querySelector: jest
-    .fn()
-    .mockImplementation(newElementMock)
-    .mockName('document.querySelector'),
-  querySelectorAll: jest
-    .fn()
-    .mockImplementation(newElementsMocks)
-    .mockName('document.querySelectorAll'),
+  getElementById: jest.fn().mockName('document.getElementById'),
+  querySelector: jest.fn().mockName('document.querySelector'),
+  querySelectorAll: jest.fn().mockName('document.querySelectorAll'),
+
+  // Common elements
+  $body: newElementMock('body'),
 
   // Utility to quickly clear the entire document mock.
   __resetAllMocks: function () {
+    this.$body = newElementMock('body');
     this.getElementById.mockClear();
     this.getElementById.mockImplementation(newElementMock);
     this.querySelector.mockClear();
-    this.querySelector.mockImplementation(newElementMock);
+    this.querySelector.mockImplementation((query) => {
+      if (query === 'body') {
+        return this.$body;
+      }
+
+      return newElementMock(query);
+    });
     this.querySelectorAll.mockClear();
     this.querySelectorAll.mockImplementation(newElementsMocks);
   },

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -1,9 +1,11 @@
-function newElementsMocks(elName) {
-  return [newElementMock(`${elName}-0`), newElementMock(`${elName}-1`)];
-}
+const PATHNAME = 'https://www.simpleicons.org';
 
 export const document = {
   getElementById: jest.fn().mockName('document.getElementById'),
+  location: {
+    pathname: PATHNAME,
+    search: '',
+  },
   querySelector: jest.fn().mockName('document.querySelector'),
   querySelectorAll: jest.fn().mockName('document.querySelectorAll'),
 
@@ -12,10 +14,11 @@ export const document = {
 
   // Utility to quickly clear the entire document mock.
   __resetAllMocks: function () {
-    this.$body = newElementMock('body');
-    this.getElementById.mockClear();
+    this.getElementById.mockReset();
     this.getElementById.mockImplementation(newElementMock);
-    this.querySelector.mockClear();
+    this.location.pathname = PATHNAME;
+    this.location.search = '';
+    this.querySelector.mockReset();
     this.querySelector.mockImplementation((query) => {
       if (query === 'body') {
         return this.$body;
@@ -23,8 +26,9 @@ export const document = {
 
       return newElementMock(query);
     });
-    this.querySelectorAll.mockClear();
-    this.querySelectorAll.mockImplementation(newElementsMocks);
+    this.querySelectorAll.mockReset();
+    this.querySelectorAll.mockReturnValue([]);
+    this.$body = newElementMock('body');
   },
 };
 
@@ -37,8 +41,11 @@ export function newElementMock(elName, opts) {
       add: jest.fn().mockName(`${elName}.classList.add`),
       remove: jest.fn().mockName(`${elName}.classList.remove`),
     },
-    removeAttribute: jest.fn().mockName(`${elName}.removeAttribute`),
+    focus: jest.fn().mockName(`${elName}.focus`),
+    getAttribute: jest.fn().mockName(`${elName}.getAttribute`),
     querySelector: jest.fn().mockName(`${elName}.querySelector`),
+    removeAttribute: jest.fn().mockName(`${elName}.removeAttribute`),
+    setAttribute: jest.fn().mockName(`${elName}.setAttribute`),
 
     // Values
     innerHTML: opts.innerHTML || '',

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -1,15 +1,8 @@
-export function newElementMock(elName) {
-  return {
-    addEventListener: jest.fn().mockName(`${elName}.addEventListener`),
-    classList: {
-      add: jest.fn().mockName(`${elName}.classList.add`),
-      remove: jest.fn().mockName(`${elName}.classList.remove`),
-    },
-    removeAttribute: jest.fn().mockName(`${elName}.removeAttribute`),
-  };
+function newElementsMocks(elName) {
+  return [newElementMock(`${elName}-0`), newElementMock(`${elName}-1`)];
 }
 
-export const documentMock = {
+export const document = {
   getElementById: jest
     .fn()
     .mockImplementation(newElementMock)
@@ -20,15 +13,34 @@ export const documentMock = {
     .mockName('document.querySelector'),
   querySelectorAll: jest
     .fn()
-    .mockImplementation((elName) => {
-      return [newElementMock(`${elName}-0`), newElementMock(`${elName}-0`)];
-    })
+    .mockImplementation(newElementsMocks)
     .mockName('document.querySelectorAll'),
 
   // Utility to quickly clear the entire document mock.
-  __clearAllMocks: function () {
-    this.querySelector.mockClear();
+  __resetAllMocks: function () {
     this.getElementById.mockClear();
+    this.getElementById.mockImplementation(newElementMock);
+    this.querySelector.mockClear();
+    this.querySelector.mockImplementation(newElementMock);
     this.querySelectorAll.mockClear();
+    this.querySelectorAll.mockImplementation(newElementsMocks);
   },
 };
+
+export function newElementMock(elName) {
+  return {
+    addEventListener: jest.fn().mockName(`${elName}.addEventListener`),
+    blur: jest.fn().mockName(`${elName}.blur`),
+    classList: {
+      add: jest.fn().mockName(`${elName}.classList.add`),
+      remove: jest.fn().mockName(`${elName}.classList.remove`),
+    },
+    removeAttribute: jest.fn().mockName(`${elName}.removeAttribute`),
+  };
+}
+
+export function newEventMock() {
+  return {
+    preventDefault: jest.fn().mockName('event.preventDefault'),
+  };
+}

--- a/tests/mocks/history.mock.js
+++ b/tests/mocks/history.mock.js
@@ -1,0 +1,8 @@
+export const history = {
+  replaceState: jest.fn().mockName('history.replaceState'),
+
+  // Utility to quickly clear the entire history mock.
+  __resetAllMocks: function () {
+    this.replaceState.mockReset();
+  },
+};

--- a/tests/mocks/local-storage.mock.js
+++ b/tests/mocks/local-storage.mock.js
@@ -1,0 +1,10 @@
+export const localStorageMock = {
+  getItem: jest.fn().mockName('localStorage.getItem'),
+  setItem: jest.fn().mockName('localStorage.setItem'),
+
+  // Utility to quickly clear the entire localStorage mock.
+  __clearAllMocks: function () {
+    this.getItem.mockClear();
+    this.setItem.mockClear();
+  },
+};

--- a/tests/mocks/local-storage.mock.js
+++ b/tests/mocks/local-storage.mock.js
@@ -10,10 +10,7 @@ function getItemImplementation(key) {
 }
 
 export const localStorage = {
-  getItem: jest
-    .fn()
-    .mockImplementation(getItemImplementation)
-    .mockName('localStorage.getItem'),
+  getItem: jest.fn().mockName('localStorage.getItem'),
   setItem: jest.fn().mockName('localStorage.setItem'),
 
   // Utility to quickly clear the entire localStorage mock.

--- a/tests/mocks/local-storage.mock.js
+++ b/tests/mocks/local-storage.mock.js
@@ -22,7 +22,7 @@ export const localStorage = {
   },
 
   // Utility to mock a stored value for a key
-  __storedValueFor: function (key, value) {
+  __setStoredValueFor: function (key, value) {
     STORAGE.set(key, value);
   },
 };

--- a/tests/mocks/local-storage.mock.js
+++ b/tests/mocks/local-storage.mock.js
@@ -1,10 +1,31 @@
-export const localStorageMock = {
-  getItem: jest.fn().mockName('localStorage.getItem'),
+const STORAGE = new Map();
+
+function getItemImplementation(key) {
+  if (!STORAGE.has(key)) {
+    // As per: https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-getitem
+    return null;
+  }
+
+  return STORAGE.get(key);
+}
+
+export const localStorage = {
+  getItem: jest
+    .fn()
+    .mockImplementation(getItemImplementation)
+    .mockName('localStorage.getItem'),
   setItem: jest.fn().mockName('localStorage.setItem'),
 
   // Utility to quickly clear the entire localStorage mock.
-  __clearAllMocks: function () {
-    this.getItem.mockClear();
-    this.setItem.mockClear();
+  __resetAllMocks: function () {
+    STORAGE.clear();
+    this.getItem.mockReset();
+    this.getItem.mockImplementation(getItemImplementation);
+    this.setItem.mockReset();
+  },
+
+  // Utility to mock a stored value for a key
+  __storedValueFor: function (key, value) {
+    STORAGE.set(key, value);
   },
 };

--- a/tests/mocks/navigator.mock.js
+++ b/tests/mocks/navigator.mock.js
@@ -1,0 +1,10 @@
+export const navigatorMock = {
+  clipboard: {
+    writeText: jest.fn().mockName('navigator.clipboard.writeText'),
+  },
+
+  // Utility to quickly clear the entire localStorage mock.
+  __clearAllMocks: function () {
+    this.clipboard.writeText.mockClear();
+  },
+};

--- a/tests/mocks/navigator.mock.js
+++ b/tests/mocks/navigator.mock.js
@@ -1,10 +1,10 @@
-export const navigatorMock = {
+export const navigator = {
   clipboard: {
     writeText: jest.fn().mockName('navigator.clipboard.writeText'),
   },
 
   // Utility to quickly clear the entire localStorage mock.
-  __clearAllMocks: function () {
-    this.clipboard.writeText.mockClear();
+  __resetAllMocks: function () {
+    this.clipboard.writeText.mockReset();
   },
 };

--- a/tests/mocks/ordering.mock.js
+++ b/tests/mocks/ordering.mock.js
@@ -1,0 +1,12 @@
+export const ordering = {
+  currentOrderingIs: jest.fn().mockName('ordering.currentOrderingIs'),
+  selectOrdering: jest.fn().mockName('ordering.selectOrdering'),
+  resetOrdering: jest.fn().mockName('ordering.resetOrdering'),
+
+  // Utility to quickly clear the entire ordering mock.
+  __resetAllMocks: function () {
+    this.currentOrderingIs.mockReset();
+    this.selectOrdering.mockReset();
+    this.resetOrdering.mockReset();
+  },
+};

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -126,10 +126,7 @@ describe('Ordering', () => {
   it('uses alphabetical ordering if no value is stored', () => {
     initOrdering(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      STORAGE_KEY_ORDERING,
-      'alphabetically',
-    );
+    expect(localStorage.setItem).not.toHaveBeenCalledWith();
   });
 
   it('uses the stored value "alphabetically"', () => {
@@ -138,13 +135,7 @@ describe('Ordering', () => {
 
     initOrdering(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
-    expect(document.$body.classList.add).toHaveBeenCalledWith(
-      'order-alphabetically',
-    );
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      STORAGE_KEY_ORDERING,
-      storedValue,
-    );
+    expect(localStorage.setItem).not.toHaveBeenCalledWith();
   });
 
   it('uses the stored value "color"', () => {

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -19,7 +19,7 @@ describe('Ordering', () => {
 
     const eventListeners = new Map();
 
-    let $orderAlphabetically = newElementMock('#order-alpha');
+    const $orderAlphabetically = newElementMock('#order-alpha');
     $orderAlphabetically.addEventListener.mockImplementation((name, fn) => {
       eventListeners.set(name, fn);
     });
@@ -58,7 +58,7 @@ describe('Ordering', () => {
 
     const eventListeners = new Map();
 
-    let $orderByColor = newElementMock('#order-color');
+    const $orderByColor = newElementMock('#order-color');
     $orderByColor.addEventListener.mockImplementation((name, fn) => {
       eventListeners.set(name, fn);
     });
@@ -95,7 +95,7 @@ describe('Ordering', () => {
   it('gets the #order-relevance button', () => {
     const eventListeners = new Map();
 
-    let $orderByRelevance = newElementMock('#order-relevance');
+    const $orderByRelevance = newElementMock('#order-relevance');
     $orderByRelevance.addEventListener.mockImplementation((name, fn) => {
       eventListeners.set(name, fn);
     });

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -15,7 +15,7 @@ describe('Ordering', () => {
   });
 
   it('gets the #order-alpha button', () => {
-    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, 'unknown');
+    localStorage.__setStoredValueFor(STORAGE_KEY_ORDERING, 'unknown');
 
     const eventListeners = new Map();
 
@@ -54,7 +54,7 @@ describe('Ordering', () => {
   });
 
   it('gets the #order-color button', () => {
-    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, 'unknown');
+    localStorage.__setStoredValueFor(STORAGE_KEY_ORDERING, 'unknown');
 
     const eventListeners = new Map();
 
@@ -134,7 +134,7 @@ describe('Ordering', () => {
 
   it('uses the stored value "alphabetically"', () => {
     const storedValue = 'alphabetically';
-    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, storedValue);
+    localStorage.__setStoredValueFor(STORAGE_KEY_ORDERING, storedValue);
 
     initOrdering(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
@@ -149,7 +149,7 @@ describe('Ordering', () => {
 
   it('uses the stored value "color"', () => {
     const storedValue = 'color';
-    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, storedValue);
+    localStorage.__setStoredValueFor(STORAGE_KEY_ORDERING, storedValue);
 
     initOrdering(document, localStorage);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -1,0 +1,162 @@
+const {
+  document,
+  newElementMock,
+  newEventMock,
+} = require('./mocks/dom.mock.js');
+const { localStorage } = require('./mocks/local-storage.mock.js');
+
+const initOrdering = require('../public/scripts/ordering.js').default;
+const { STORAGE_KEY_ORDERING } = require('../public/scripts/storage.js');
+
+describe('Ordering', () => {
+  beforeEach(() => {
+    document.__resetAllMocks();
+    localStorage.__resetAllMocks();
+  });
+
+  it('gets the #order-alpha button', () => {
+    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, 'unknown');
+
+    const eventListeners = new Map();
+
+    let $orderAlphabetically = newElementMock('#order-alpha');
+    $orderAlphabetically.addEventListener.mockImplementation((name, fn) => {
+      eventListeners.set(name, fn);
+    });
+
+    document.getElementById.mockImplementation((query) => {
+      if (query === 'order-alpha') {
+        return $orderAlphabetically;
+      }
+
+      return newElementMock(query);
+    });
+
+    initOrdering(document, localStorage);
+    expect(document.getElementById).toHaveBeenCalledWith('order-alpha');
+    expect($orderAlphabetically.disabled).toBe(false);
+    expect($orderAlphabetically.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+
+    localStorage.setItem.mockClear();
+
+    const clickListener = eventListeners.get('click');
+    const event = newEventMock();
+    clickListener(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect($orderAlphabetically.blur).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_ORDERING,
+      'alphabetically',
+    );
+  });
+
+  it('gets the #order-color button', () => {
+    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, 'unknown');
+
+    const eventListeners = new Map();
+
+    let $orderByColor = newElementMock('#order-color');
+    $orderByColor.addEventListener.mockImplementation((name, fn) => {
+      eventListeners.set(name, fn);
+    });
+
+    document.getElementById.mockImplementation((query) => {
+      if (query === 'order-color') {
+        return $orderByColor;
+      }
+
+      return newElementMock(query);
+    });
+
+    initOrdering(document, localStorage);
+    expect(document.getElementById).toHaveBeenCalledWith('order-color');
+    expect($orderByColor.disabled).toBe(false);
+    expect($orderByColor.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+
+    localStorage.setItem.mockClear();
+
+    const clickListener = eventListeners.get('click');
+    const event = newEventMock();
+    clickListener(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect($orderByColor.blur).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_ORDERING,
+      'color',
+    );
+  });
+
+  it('gets the #order-relevance button', () => {
+    const eventListeners = new Map();
+
+    let $orderByRelevance = newElementMock('#order-relevance');
+    $orderByRelevance.addEventListener.mockImplementation((name, fn) => {
+      eventListeners.set(name, fn);
+    });
+
+    document.getElementById.mockImplementation((query) => {
+      if (query === 'order-relevance') {
+        return $orderByRelevance;
+      }
+
+      return newElementMock(query);
+    });
+
+    initOrdering(document, localStorage);
+    expect(document.getElementById).toHaveBeenCalledWith('order-relevance');
+    expect($orderByRelevance.disabled).toBe(false);
+    expect($orderByRelevance.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+
+    const clickListener = eventListeners.get('click');
+    const event = newEventMock();
+    clickListener(event);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect($orderByRelevance.blur).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses alphabetical ordering if no value is stored', () => {
+    initOrdering(document, localStorage);
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_ORDERING,
+      'alphabetically',
+    );
+  });
+
+  it('uses the stored value "alphabetically"', () => {
+    const storedValue = 'alphabetically';
+    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, storedValue);
+
+    initOrdering(document, localStorage);
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
+    expect(document.$body.classList.add).toHaveBeenCalledWith(
+      'order-alphabetically',
+    );
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_ORDERING,
+      storedValue,
+    );
+  });
+
+  it('uses the stored value "color"', () => {
+    const storedValue = 'color';
+    localStorage.__storedValueFor(STORAGE_KEY_ORDERING, storedValue);
+
+    initOrdering(document, localStorage);
+    expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
+    expect(document.$body.classList.add).toHaveBeenCalledWith('order-by-color');
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY_ORDERING,
+      storedValue,
+    );
+  });
+});

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,0 +1,11 @@
+const { document } = require('./mocks/dom.mock.js');
+
+const initSearch = require('../public/scripts/search.js').default;
+
+describe('Search', () => {
+  beforeEach(() => {
+    document.__resetAllMocks();
+  });
+
+  it.todo('does something');
+});

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,11 +1,200 @@
-const { document } = require('./mocks/dom.mock.js');
+const { domUtils } = require('./mocks/dom-utils.mock.js');
+const {
+  document,
+  newElementMock,
+  newEventMock,
+} = require('./mocks/dom.mock.js');
+const { history } = require('./mocks/history.mock.js');
+const { ordering } = require('./mocks/ordering.mock.js');
 
+const { ORDER_BY_RELEVANCE } = require('../public/scripts/ordering.js');
 const initSearch = require('../public/scripts/search.js').default;
 
 describe('Search', () => {
+  const inputEventListeners = new Map();
+  const clearEventListeners = new Map();
+
+  let $searchInput;
+  let $searchClear;
+  let $adSpace;
+  let $orderByRelevance;
+
   beforeEach(() => {
+    domUtils.__resetAllMocks();
     document.__resetAllMocks();
+    history.__resetAllMocks();
+    ordering.__resetAllMocks();
   });
 
-  it.todo('does something');
+  beforeEach(() => {
+    $searchInput = newElementMock('#search-input');
+    $searchInput.value = '';
+    $searchInput.addEventListener.mockImplementation((name, fn) => {
+      inputEventListeners.set(name, fn);
+    });
+
+    $searchClear = newElementMock('#search-clear');
+    $searchClear.addEventListener.mockImplementation((name, fn) => {
+      clearEventListeners.set(name, fn);
+    });
+
+    $adSpace = newElementMock('#carbonads');
+    $orderByRelevance = newElementMock('#order-relevance');
+
+    document.getElementById.mockImplementation((query) => {
+      switch (query) {
+        case 'search-input':
+          return $searchInput;
+        case 'search-clear':
+          return $searchClear;
+        case 'carbonads':
+          return $adSpace;
+        case 'order-relevance':
+          return $orderByRelevance;
+        default:
+          return newElementMock(query);
+      }
+    });
+
+    initSearch(history, document, ordering, domUtils);
+  });
+
+  it('gets all elements of interest', () => {
+    expect(document.getElementById).toHaveBeenCalledWith('search-input');
+    expect(document.getElementById).toHaveBeenCalledWith('search-clear');
+    expect(document.getElementById).toHaveBeenCalledWith('order-relevance');
+    expect(document.getElementById).toHaveBeenCalledWith('carbonads');
+    expect($searchInput.disabled).toBe(false);
+    expect($searchInput.focus).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Searching', () => {
+    it('works if a value is searched for', (done) => {
+      const searchValue = 'foobar';
+
+      expect($searchInput.addEventListener).toHaveBeenCalledWith(
+        'input',
+        expect.any(Function),
+      );
+
+      const inputListener = inputEventListeners.get('input');
+      const event = newEventMock();
+
+      $searchInput.value = searchValue;
+      inputListener(event);
+
+      setTimeout(() => {
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(ordering.selectOrdering).toHaveBeenCalledWith(
+          ORDER_BY_RELEVANCE,
+        );
+        expect(history.replaceState).toHaveBeenCalledWith(
+          null,
+          '',
+          expect.stringMatching(
+            `${document.location.pathname}?.*=${searchValue}$`,
+          ),
+        );
+
+        expect(domUtils.showElement).toHaveBeenCalledWith($searchClear);
+        expect(domUtils.showElement).toHaveBeenCalledWith($orderByRelevance);
+        expect(domUtils.hideElement).toHaveBeenCalledWith($adSpace);
+
+        done();
+      }, 500);
+    });
+
+    it('works if the search input is emptied', (done) => {
+      ordering.currentOrderingIs.mockReturnValue(true);
+
+      expect($searchInput.addEventListener).toHaveBeenCalledWith(
+        'input',
+        expect.any(Function),
+      );
+
+      const inputListener = inputEventListeners.get('input');
+      const event = newEventMock();
+
+      $searchInput.value = '';
+      inputListener(event);
+
+      setTimeout(() => {
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(ordering.resetOrdering).toHaveBeenCalledTimes(1);
+        expect(history.replaceState).toHaveBeenCalledWith(
+          null,
+          '',
+          document.location.pathname,
+        );
+
+        expect(domUtils.hideElement).toHaveBeenCalledWith($searchClear);
+        expect(domUtils.hideElement).toHaveBeenCalledWith($orderByRelevance);
+        expect(domUtils.showElement).toHaveBeenCalledWith($adSpace);
+
+        done();
+      }, 500);
+    });
+
+    it('works if the clear search button is clicked', (done) => {
+      ordering.currentOrderingIs.mockReturnValue(true);
+
+      expect($searchClear.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function),
+      );
+
+      const clickListener = clearEventListeners.get('click');
+      const event = newEventMock();
+
+      $searchInput.value = 'Hello world!';
+      clickListener(event);
+
+      setTimeout(() => {
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(ordering.resetOrdering).toHaveBeenCalledTimes(1);
+        expect(history.replaceState).toHaveBeenCalledWith(
+          null,
+          '',
+          document.location.pathname,
+        );
+
+        expect(domUtils.hideElement).toHaveBeenCalledWith($searchClear);
+        expect(domUtils.hideElement).toHaveBeenCalledWith($orderByRelevance);
+        expect(domUtils.showElement).toHaveBeenCalledWith($adSpace);
+
+        done();
+      }, 500);
+    });
+  });
+
+  describe('URL query', () => {
+    it('has no search query in the URL', () => {
+      document.location.search = '';
+
+      initSearch(history, document, ordering, domUtils);
+
+      expect($searchInput.value).toEqual('');
+      expect(domUtils.showElement).not.toHaveBeenCalled();
+      expect(domUtils.hideElement).not.toHaveBeenCalled();
+      expect(history.replaceState).not.toHaveBeenCalled();
+      expect(ordering.selectOrdering).not.toHaveBeenCalled();
+      expect(ordering.currentOrderingIs).not.toHaveBeenCalled();
+      expect(ordering.resetOrdering).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['foobar', 'foobar'],
+      ['foo%3Dbar', 'foo=bar'],
+    ])('initialized based on a search query in the URL', (query, expected) => {
+      document.location.search = `?q=${query}`;
+
+      initSearch(history, document, ordering, domUtils);
+
+      expect($searchInput.value).toEqual(expected);
+      expect(domUtils.showElement).toHaveBeenCalled();
+      expect(domUtils.hideElement).toHaveBeenCalled();
+      expect(history.replaceState).toHaveBeenCalled();
+      expect(ordering.selectOrdering).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,29 @@
+const { localStorage } = require('./mocks/local-storage.mock.js');
+
+const newStorage = require('../public/scripts/storage.js').default;
+
+describe('Storage', () => {
+  beforeEach(() => localStorage.__resetAllMocks());
+
+  it('returns something if input is not defined', () => {
+    const result = newStorage(undefined);
+    expect(result.getItem).toBeInstanceOf(Function);
+    expect(result.setItem).toBeInstanceOf(Function);
+  });
+
+  it('wraps the provided `localStorage`', () => {
+    const result = newStorage(localStorage);
+
+    localStorage.getItem.mockReturnValue('bar');
+    const item = result.getItem('foo');
+    expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledTimes(0);
+    expect(item).toBe('bar');
+
+    localStorage.__resetAllMocks();
+
+    result.setItem('foo', 'bar');
+    expect(localStorage.getItem).toHaveBeenCalledTimes(0);
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -20,7 +20,7 @@ describe('::decodeURIComponent', () => {
   });
 });
 
-describe.only('::debounce', () => {
+describe('::debounce', () => {
   it('calls the debounced function only once', (done) => {
     const spy = jest.fn();
     const debouncedImmediateSpy = debounce(spy, 1000, true);


### PR DESCRIPTION
Add tests for all `public/scripts` files, and improve some of those files as well. More specifically:

- `color-scheme.js`
  - Keep state in function scope (simplifies testing)
  - Check active color scheme in `selectColorScheme` (reduces duplication)
- `ordering.js`
  - Keep state in function scope (simplifies testing)
  - Check active ordering in `selectOrdering` (reduces duplication)
- `search.js`
  - Keep state in function scope (simplifies testing)
  - Make `dom-utils.js` a function parameter (simplifies testing)
  - Use `document.location` in `getQueryFromParameter` (should have been this way from the start)
  - Get ads element by ID (should have been this way from the start)