### PR TITLE
Add lazy loading using `loading="lazy"`

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -98,8 +98,8 @@ html
 
         each icon in icons
           li(class="grid-item" style=`--order-color: ${icon.indexByColor}` data-brand=`${icon.normalizedName}`)
-            svg(class="grid-item__decoration" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
-              use(href=`#${icon.slug}-svg`)
+            //- svg(class="grid-item__decoration" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
+            //-   use(href=`#${icon.slug}-svg`)
             h2(class="grid-item__title") #{icon.title}
             button(
               class=`grid-item__color copy-button ${icon.light ? "contrast-light" : "contrast-dark"} ${icon.superLight ? "border-light" : ""}  ${icon.superDark ? "border-dark" : ""}`
@@ -125,9 +125,7 @@ html
               ) #{icon.license.type}
             div(class="grid-item__footer")
               button(class="grid-item__preview copy-button" title=`${icon.title} SVG` disabled)
-                svg(id=`${icon.slug}-svg` role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
-                  title #{icon.title} icon
-                  path(d=icon.path)
+                img(src=`./icons/${icon.slug}.svg` loading="lazy")
               div(class="grid-item__downloads")
                 h3 Download
                 div(class="grid-item__button-row")

--- a/public/index.pug
+++ b/public/index.pug
@@ -152,7 +152,7 @@ html
       )
         svg(class="footer-share--icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
           title Twitter logo
-          use(href=`#twitter-svg`)
+          path(d=twitterIcon.path)
         span Share this on Twitter!
 
     input(id="copy-input" class="hidden" aria-hidden="true")

--- a/public/index.pug
+++ b/public/index.pug
@@ -125,7 +125,8 @@ html
               ) #{icon.license.type}
             div(class="grid-item__footer")
               button(class="grid-item__preview copy-button" title=`${icon.title} SVG` disabled)
-                img(src=`./icons/${icon.slug}.svg` loading="lazy")
+                img(src=`./icons/${icon.slug}.svg` loading="lazy" class="icon-black")
+                img(src=`./icons/${icon.slug}-white.svg` loading="lazy" class="icon-white")
               div(class="grid-item__downloads")
                 h3 Download
                 div(class="grid-item__button-row")

--- a/public/index.pug
+++ b/public/index.pug
@@ -98,8 +98,6 @@ html
 
         each icon in icons
           li(class="grid-item" style=`--order-color: ${icon.indexByColor}` data-brand=`${icon.normalizedName}`)
-            //- svg(class="grid-item__decoration" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
-            //-   use(href=`#${icon.slug}-svg`)
             h2(class="grid-item__title") #{icon.title}
             button(
               class=`grid-item__color copy-button ${icon.light ? "contrast-light" : "contrast-dark"} ${icon.superLight ? "border-light" : ""}  ${icon.superDark ? "border-dark" : ""}`
@@ -125,7 +123,7 @@ html
               ) #{icon.license.type}
             div(class="grid-item__footer")
               button(class="grid-item__preview copy-button" title=`${icon.title} SVG` disabled)
-                img(src=`./icons/${icon.slug}.svg` loading="lazy" class="icon-preview")
+                img(src=`data:image/svg+xml;base64,${icon.base64Svg}` loading="lazy" class="icon-preview")
               div(class="grid-item__downloads")
                 h3 Download
                 div(class="grid-item__button-row")

--- a/public/index.pug
+++ b/public/index.pug
@@ -125,7 +125,7 @@ html
               ) #{icon.license.type}
             div(class="grid-item__footer")
               button(class="grid-item__preview copy-button" title=`${icon.title} SVG` disabled)
-                img(src=`data:image/svg+xml;base64,${icon.base64Svg}` loading="lazy" class="icon-preview")
+                img(src=`./icons/${icon.slug}.svg` loading="lazy" class="icon-preview")
               div(class="grid-item__downloads")
                 h3 Download
                 div(class="grid-item__button-row")

--- a/public/index.pug
+++ b/public/index.pug
@@ -125,8 +125,7 @@ html
               ) #{icon.license.type}
             div(class="grid-item__footer")
               button(class="grid-item__preview copy-button" title=`${icon.title} SVG` disabled)
-                img(src=`./icons/${icon.slug}.svg` loading="lazy" class="icon-black")
-                img(src=`./icons/${icon.slug}-white.svg` loading="lazy" class="icon-white")
+                img(src=`data:image/svg+xml;base64,${icon.base64Svg}` loading="lazy" class="icon-preview")
               div(class="grid-item__downloads")
                 h3 Download
                 div(class="grid-item__button-row")

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -28,11 +28,10 @@ export default function initCopyButtons(document, navigator) {
       event.preventDefault();
 
       const $img = $svgButton.querySelector('img');
-      const svgUrl = $img.src;
-      const response = await fetch(svgUrl);
-      const rawSvg = await response.text();
-
-      const value = rawSvg;
+      const srcValue = $img.getAttribute('src');
+      const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
+      console.log(base64Svg);
+      const value = atob(base64Svg);
       $svgButton.blur();
       copyValue(value);
       setCopied($svgButton);

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -24,14 +24,14 @@ export default function initCopyButtons(document, navigator) {
 
   $svgButtons.forEach(($svgButton) => {
     $svgButton.removeAttribute('disabled');
-    $svgButton.addEventListener('click', async (event) => {
+    $svgButton.addEventListener('click', (event) => {
       event.preventDefault();
 
-      const svgUrl = $svgButton.children[0].src;
-      const response = await fetch(svgUrl);
-      const rawSvg = await response.text();
+      const $img = $svgButton.querySelector('img');
+      const srcValue = $img.getAttribute('src');
+      const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
 
-      const value = rawSvg;
+      const value = atob(base64Svg);
       $svgButton.blur();
       copyValue(value);
       setCopied($svgButton);

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -5,7 +5,7 @@ function setCopied($el) {
   setTimeout(() => $el.classList.remove('copied'), COPIED_TIMEOUT);
 }
 
-export default function initCopyButtons(document, navigator) {
+export default function initCopyButtons(window, document, navigator) {
   const $copyInput = document.getElementById('copy-input');
   const $colorButtons = document.querySelectorAll('.grid-item__color');
   const $svgButtons = document.querySelectorAll('.grid-item__preview');
@@ -31,7 +31,7 @@ export default function initCopyButtons(document, navigator) {
       const srcValue = $img.getAttribute('src');
       const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
 
-      const value = atob(base64Svg);
+      const value = window.atob(base64Svg);
       $svgButton.blur();
       copyValue(value);
       setCopied($svgButton);

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -24,7 +24,7 @@ export default function initCopyButtons(document, navigator) {
 
   $svgButtons.forEach(($svgButton) => {
     $svgButton.removeAttribute('disabled');
-    $svgButton.addEventListener('click', async (event) => {
+    $svgButton.addEventListener('click', (event) => {
       event.preventDefault();
 
       const $img = $svgButton.querySelector('img');

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -30,7 +30,7 @@ export default function initCopyButtons(document, navigator) {
       const $img = $svgButton.querySelector('img');
       const srcValue = $img.getAttribute('src');
       const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
-      console.log(base64Svg);
+
       const value = atob(base64Svg);
       $svgButton.blur();
       copyValue(value);

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -24,14 +24,15 @@ export default function initCopyButtons(document, navigator) {
 
   $svgButtons.forEach(($svgButton) => {
     $svgButton.removeAttribute('disabled');
-    $svgButton.addEventListener('click', (event) => {
+    $svgButton.addEventListener('click', async (event) => {
       event.preventDefault();
 
       const $img = $svgButton.querySelector('img');
-      const srcValue = $img.getAttribute('src');
-      const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
+      const svgUrl = $img.src;
+      const response = await fetch(svgUrl);
+      const rawSvg = await response.text();
 
-      const value = atob(base64Svg);
+      const value = rawSvg;
       $svgButton.blur();
       copyValue(value);
       setCopied($svgButton);

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -24,11 +24,14 @@ export default function initCopyButtons(document, navigator) {
 
   $svgButtons.forEach(($svgButton) => {
     $svgButton.removeAttribute('disabled');
-    $svgButton.addEventListener('click', (event) => {
+    $svgButton.addEventListener('click', async (event) => {
       event.preventDefault();
 
-      const $svg = $svgButton.parentNode.querySelector('svg');
-      const value = $svg.outerHTML;
+      const svgUrl = $svgButton.children[0].src;
+      const response = await fetch(svgUrl);
+      const rawSvg = await response.text();
+
+      const value = rawSvg;
       $svgButton.blur();
       copyValue(value);
       setCopied($svgButton);

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -13,7 +13,7 @@ document.body.classList.remove('no-js');
 
 const storage = newStorage(localStorage);
 initColorScheme(document, storage);
-initCopyButtons(document, navigator);
+initCopyButtons(window, document, navigator);
 const orderingControls = initOrdering(document, storage);
 initSearch(window.history, document, orderingControls, domUtils);
 initFeedbackRequest(document, storage);

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -100,6 +100,10 @@
     --color-link-hover: var(--dm-color-link-hover);
     --color-link-visited: var(--dm-color-link-visited);
   }
+
+  body:not(.dark):not(.light) .icon-black {
+    display: none;
+  }
 }
 @media (prefers-color-scheme: light) {
   :root {
@@ -123,6 +127,10 @@
     --color-link: var(--lm-color-link);
     --color-link-hover: var(--lm-color-link-hover);
     --color-link-visited: var(--lm-color-link-visited);
+  }
+
+  body:not(.dark):not(.light) .icon-white {
+    display: none;
   }
 }
 
@@ -169,6 +177,13 @@ body.light {
   --color-link: var(--lm-color-link);
   --color-link-hover: var(--lm-color-link-hover);
   --color-link-visited: var(--lm-color-link-visited);
+}
+
+body.dark .icon-black {
+  display: none;
+}
+body.light .icon-white {
+  display: none;
 }
 
 /* General */

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -101,8 +101,8 @@
     --color-link-visited: var(--dm-color-link-visited);
   }
 
-  body:not(.dark):not(.light) .icon-black {
-    display: none;
+  body:not(.dark):not(.light) .icon-preview {
+    filter: invert(1);
   }
 }
 @media (prefers-color-scheme: light) {
@@ -127,10 +127,6 @@
     --color-link: var(--lm-color-link);
     --color-link-hover: var(--lm-color-link-hover);
     --color-link-visited: var(--lm-color-link-visited);
-  }
-
-  body:not(.dark):not(.light) .icon-white {
-    display: none;
   }
 }
 
@@ -179,11 +175,8 @@ body.light {
   --color-link-visited: var(--lm-color-link-visited);
 }
 
-body.dark .icon-black {
-  display: none;
-}
-body.light .icon-white {
-  display: none;
+body.dark .icon-preview {
+  filter: invert(1);
 }
 
 /* General */

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -520,6 +520,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
 @media (hover: hover) {
   .grid-item__preview .copy-button:not(:disabled):hover::before {
     display: block;
+    z-index: 1;
   }
 }
 

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -63,7 +63,7 @@ describe('Copy', () => {
     }
   });
 
-  it('gets grid item copy SVG source buttons', () => {
+  it.skip('gets grid item copy SVG source buttons', () => {
     const eventListeners = new Map();
     const $svgButtons = [
       newElementMock('preview button 1', { parentNode: true }),

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -63,7 +63,10 @@ describe('Copy', () => {
     }
   });
 
-  it.skip('gets grid item copy SVG source buttons', () => {
+  it('gets grid item copy SVG source buttons', () => {
+    const rawSvg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+    const base64Svg = Buffer.from(rawSvg).toString('base64');
     const eventListeners = new Map();
     const $svgButtons = [
       newElementMock('preview button 1', { parentNode: true }),
@@ -90,11 +93,11 @@ describe('Copy', () => {
     for (const $svgButton of $svgButtons) {
       const buttonEventListeners = eventListeners.get($svgButton);
 
-      const $svg = newElementMock('svg');
-      $svg.outerHTML = `<svg>${$svgButton.__name}</svg>`;
-
-      const $parent = $svgButton.parentNode;
-      $parent.querySelector.mockReturnValue($svg);
+      const $img = newElementMock('img');
+      $img.getAttribute.mockReturnValue(
+        `data:image/svg+xml;base64,${base64Svg}`,
+      );
+      $svgButton.querySelector.mockReturnValue($img);
 
       expect($svgButton.removeAttribute).toHaveBeenCalledWith('disabled');
       expect($svgButton.addEventListener).toHaveBeenCalledWith(
@@ -108,10 +111,7 @@ describe('Copy', () => {
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect($svgButton.blur).toHaveBeenCalledTimes(1);
       expect($svgButton.classList.add).toHaveBeenCalledWith('copied');
-      expect($parent.querySelector).toHaveBeenCalledWith('svg');
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        $svg.outerHTML,
-      );
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(rawSvg);
     }
   });
 });

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -2,6 +2,7 @@ const {
   document,
   newElementMock,
   newEventMock,
+  window,
 } = require('./mocks/dom.mock.js');
 const { navigator } = require('./mocks/navigator.mock.js');
 
@@ -14,7 +15,7 @@ describe('Copy', () => {
   });
 
   it('gets the #copy-input button', () => {
-    initCopyButtons(document, navigator);
+    initCopyButtons(window, document, navigator);
     expect(document.getElementById).toHaveBeenCalledWith('copy-input');
   });
 
@@ -41,7 +42,7 @@ describe('Copy', () => {
       return [];
     });
 
-    initCopyButtons(document, navigator);
+    initCopyButtons(window, document, navigator);
     for (const $colorButton of $colorButtons) {
       const buttonEventListeners = eventListeners.get($colorButton);
 
@@ -89,7 +90,7 @@ describe('Copy', () => {
       return [];
     });
 
-    initCopyButtons(document, navigator);
+    initCopyButtons(window, document, navigator);
     for (const $svgButton of $svgButtons) {
       const buttonEventListeners = eventListeners.get($svgButton);
 

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -63,3 +63,7 @@ export function newEventMock() {
     preventDefault: jest.fn().mockName('event.preventDefault'),
   };
 }
+
+export const window = {
+  atob: (base64Str) => Buffer.from(base64Str, 'base64').toString('utf8'),
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,14 @@ module.exports = {
           filter: (path) => path.endsWith('.svg'),
         },
         {
+          from: path.resolve(NODE_MODULES, 'simple-icons/icons'),
+          to: path.resolve(OUT_DIR, 'icons', `[name]-white.[ext]`),
+          filter: (path) => path.endsWith('.svg'),
+          transform(content) {
+            return content.toString().replace('<svg', '<svg fill="#FFF"');
+          },
+        },
+        {
           from: path.resolve(NODE_MODULES, 'simple-icons-pdf/icons'),
           to: path.resolve(OUT_DIR, 'icons'),
           filter: (path) => path.endsWith('.pdf'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,6 +94,7 @@ module.exports = {
           };
         }),
         iconCount: icons.length,
+        twitterIcon: icons.find((icon) => icon.title === 'Twitter'),
       },
     }),
     new MiniCssExtractPlugin(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,6 @@ module.exports = {
             normalizedName: normalizeSearchTerm(icon.title),
             path: icon.path,
             shortHex: simplifyHexIfPossible(icon.hex),
-            base64Svg: Buffer.from(icon.svg).toString('base64'),
             slug: icon.slug,
             title: icon.title,
           };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,14 +60,6 @@ module.exports = {
           filter: (path) => path.endsWith('.svg'),
         },
         {
-          from: path.resolve(NODE_MODULES, 'simple-icons/icons'),
-          to: path.resolve(OUT_DIR, 'icons', `[name]-white.[ext]`),
-          filter: (path) => path.endsWith('.svg'),
-          transform(content) {
-            return content.toString().replace('<svg', '<svg fill="#FFF"');
-          },
-        },
-        {
           from: path.resolve(NODE_MODULES, 'simple-icons-pdf/icons'),
           to: path.resolve(OUT_DIR, 'icons'),
           filter: (path) => path.endsWith('.pdf'),
@@ -85,6 +77,7 @@ module.exports = {
         icons: icons.map((icon, iconIndex) => {
           const luminance = getRelativeLuminance(`#${icon.hex}`);
           return {
+            base64Svg: Buffer.from(icon.svg).toString('base64'),
             guidelines: icon.guidelines,
             hex: icon.hex,
             indexByAlpha: iconIndex,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,7 @@ module.exports = {
             normalizedName: normalizeSearchTerm(icon.title),
             path: icon.path,
             shortHex: simplifyHexIfPossible(icon.hex),
+            base64Svg: Buffer.from(icon.svg).toString('base64'),
             slug: icon.slug,
             title: icon.title,
           };


### PR DESCRIPTION
Addresses #37 by replacing the inline `<svg>`s with `<img>`s with the SVG Base-64 encoded on the `src` and `loading="lazy"`. This makes it so that the images are not loaded until they're in view. If `loading="lazy"` is not supported by the browser all icons are loaded immediately (same behaviour as current `master`).

For more details on the trade-offs of various approached we can take, see [this comment](https://github.com/simple-icons/simple-icons-website/pull/55#issuecomment-826394479).

### Preview

https://user-images.githubusercontent.com/3742559/116010501-9f324180-a61f-11eb-950f-44e41893919c.mp4

