### PR TITLE
Update card design

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -97,49 +97,46 @@ html
 
         each icon in icons
           li(class="grid-item" style=`--order-color: ${icon.indexByColor}` data-brand=`${icon.normalizedName}`)
-            svg(class="grid-item__decoration" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
-              use(href=`#${icon.slug}-svg`)
-            h2(class="grid-item__title") #{icon.title}
-            button(
-              class=`grid-item__color copy-button ${icon.light ? "contrast-light" : "contrast-dark"} ${icon.superLight ? "border-light" : ""}  ${icon.superDark ? "border-dark" : ""}`
-              style=`background-color: #${icon.shortHex}`
-              title=`${icon.title} color`
-              disabled
-            ) ##{icon.hex}
-            if icon.guidelines
-              a(
-                class="grid-item__guidelines link-button"
-                title=`${icon.title} guidelines`
-                href=icon.guidelines
-                rel="noopener"
-                target="_blank"
-              ) Brand Guidelines
-            if icon.license
-              a(
-                class="grid-item__legal"
-                title=`${icon.title} icon license`
-                href=icon.license.url
-                rel="noopener"
-                target="_blank"
-              ) #{icon.license.type}
-            div(class="grid-item__footer")
-              button(class="grid-item__preview copy-button" title=`${icon.title} SVG` disabled)
+            div(class="grid-item__preview")
+              button(class="copy-button copy-svg" title=`${icon.title} SVG` disabled)
                 svg(id=`${icon.slug}-svg` role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg")
                   title #{icon.title} icon
                   path(d=icon.path)
-              div(class="grid-item__downloads")
-                h3 Download
-                div(class="grid-item__button-row")
-                  a(
-                    class="grid-item__button"
-                    href=`./icons/${icon.slug}.svg`
-                    download
-                  ) SVG
-                  a(
-                    class="grid-item__button"
-                    href=`./icons/${icon.slug}.pdf`
-                    download
-                  ) PDF
+            div(class="grid-item__row")
+              if icon.guidelines
+                a(
+                  class="grid-item__guidelines link-button"
+                  title=`${icon.title} guidelines`
+                  href=icon.guidelines
+                  rel="noopener"
+                  target="_blank"
+                ) Brand Guidelines
+              if icon.license
+                a(
+                  class="grid-item__legal"
+                  title=`${icon.title} icon license`
+                  href=icon.license.url
+                  rel="noopener"
+                  target="_blank"
+                ) #{icon.license.type}
+              h2(class="grid-item__title") #{icon.title}
+            div(class="grid-item__footer")
+              button(
+                class=`grid-item__color copy-button copy-color ${icon.light ? "contrast-light" : "contrast-dark"} ${icon.superLight ? "border-light" : ""}  ${icon.superDark ? "border-dark" : ""}`
+                style=`background-color: #${icon.shortHex}`
+                title=`${icon.title} color`
+                disabled
+              ) ##{icon.hex}
+              a(
+                class="grid-item__button"
+                href=`./icons/${icon.slug}.svg`
+                download
+              ) SVG
+              a(
+                class="grid-item__button"
+                href=`./icons/${icon.slug}.pdf`
+                download
+              ) PDF
 
     footer(class="footer" role="contentinfo")
       div(class="footer-description")

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -7,8 +7,8 @@ function setCopied($el) {
 
 export default function initCopyButtons(document, navigator) {
   const $copyInput = document.getElementById('copy-input');
-  const $colorButtons = document.querySelectorAll('.grid-item__color');
-  const $svgButtons = document.querySelectorAll('.grid-item__preview');
+  const $colorButtons = document.querySelectorAll('.copy-color');
+  const $svgButtons = document.querySelectorAll('.copy-svg');
 
   $colorButtons.forEach(($colorButton) => {
     $colorButton.removeAttribute('disabled');

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -21,7 +21,7 @@
   --dm-asset-svg-external-link: url(./assets/external-link-white.svg);
   --dm-asset-svg-legal: url(./assets/legal-white.svg);
   --dm-color-background: rgb(34, 34, 34);
-  --dm-color-background-transparent: rgba(34, 34, 34, 0.7);
+  --dm-color-background-transparent: rgba(20, 20, 20, 0.7);
   --dm-color-background-card: rgb(20, 20, 20);
   --dm-color-text-default: rgb(236, 236, 236);
   --dm-color-text-light: rgb(170, 170, 170);
@@ -43,7 +43,7 @@
   --lm-asset-svg-external-link: url(./assets/external-link.svg);
   --lm-asset-svg-legal: url(./assets/legal.svg);
   --lm-color-background: rgb(252, 252, 252);
-  --lm-color-background-transparent: rgba(252, 252, 252, 0.7);
+  --lm-color-background-transparent: rgba(255, 255, 255, 0.7);
   --lm-color-background-card: rgb(255, 255, 255);
   --lm-color-text-default: rgb(0, 0, 0);
   --lm-color-text-light: rgb(102, 102, 102);
@@ -59,7 +59,7 @@
   --lm-color-link-hover: rgb(52, 52, 238);
   --lm-color-link-visited: rgb(85, 26, 139);
 }
-@media (max-width: 1080px) {
+@media (max-width: 1280px) {
   :root {
     --side-offset: 3rem;
   }
@@ -467,10 +467,9 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  justify-content: flex-end;
+  justify-content: flex-start;
   margin: 0.4rem;
   overflow: hidden;
-  padding-top: 2.5rem;
   position: relative;
   width: 224px;
 }
@@ -482,45 +481,68 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   }
 }
 
-.grid-item__decoration {
+.grid-item__preview {
+  box-sizing: border-box;
   fill: var(--color-svg-default);
-  height: 6rem;
-  opacity: 0.05;
+  flex-grow: 2;
+  margin: 1.5rem auto 0.6rem;
+}
+.grid-item__preview .copy-button {
+  cursor: default; /* This should function as decoration when JS is disabled */
+  height: 3.5rem;
+  position: relative;
+  width: 3.5rem;
+}
+.grid-item__preview .copy-button::before {
+  background-color: var(--color-background-transparent);
+  background-size: 1.7rem 1.7rem;
+  content: '';
+  cursor: pointer;
+  display: none;
+  height: 100%;
+  left: 0;
   position: absolute;
-  right: -2rem;
-  top: -1.5rem;
-  width: 6rem;
+  top: 0;
+  width: 100%;
+}
+.grid-item__preview .copy-button:not(:disabled).copied::before,
+.grid-item__preview .copy-button:not(:disabled):focus::before {
+  display: block;
+}
+@media (hover: hover) {
+  .grid-item__preview .copy-button:not(:disabled):hover::before {
+    display: block;
+  }
 }
 
+.grid-item__row {
+  padding: 0 2rem 0 1rem;
+  width: 100%;
+}
 .grid-item__title {
   font-family: 'Open Sans', sans-serif;
   font-size: 1.2rem;
   font-weight: 600;
   line-height: 1.5rem;
-  margin: 0.4rem 1.7rem 0.4rem 1rem;
-  padding-right: 2rem;
+  margin: 0.4rem 0;
 }
 
 .grid-item__color {
-  border: 1px solid transparent;
+  border-top: 1px solid var(--color-grid-item-divider);
   color: #000;
-  cursor: text; /* This should function as text when JS is disabled */
+  flex-grow: 2;
   font-family: 'Roboto Mono', monospace;
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 1px;
   line-height: 1rem;
-  margin: 0.2rem 1rem;
   overflow: hidden;
-  padding: 6px 8px;
+  padding: 8px;
   position: relative;
+
+  /* Make this element behave as text when JS is disabled */
+  cursor: text;
   user-select: text;
-}
-.grid-item__color.border-light {
-  border-color: var(--dm-color-background-card);
-}
-.grid-item__color.border-dark {
-  border-color: var(--lm-color-background-card);
 }
 .grid-item__color.contrast-light {
   color: #fff;
@@ -548,29 +570,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   }
 }
 
-.grid-item__guidelines {
-  align-items: center;
-  color: var(--color-text-default);
-  display: flex;
-  flex-direction: row;
-  font-family: 'Roboto Mono', monospace;
-  font-size: 0.8rem;
-  line-height: 1rem;
-  margin: 0.3rem 1rem 0.2rem;
-  opacity: 0.6;
-  outline: none;
-}
-.grid-item__guidelines:focus {
-  opacity: 1;
-  text-decoration: underline;
-}
-@media (hover: hover) {
-  .grid-item__guidelines:hover {
-    opacity: 1;
-    text-decoration: underline;
-  }
-}
-
+.grid-item__guidelines,
 .grid-item__legal {
   align-items: center;
   color: var(--color-text-default);
@@ -579,10 +579,23 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   font-family: 'Roboto Mono', monospace;
   font-size: 0.8rem;
   line-height: 1rem;
-  margin: 0.3rem 1rem 0.2rem;
+  margin: 0.3rem 0;
   opacity: 0.6;
   outline: none;
 }
+.grid-item__guidelines:focus,
+.grid-item__legal:focus {
+  opacity: 1;
+  text-decoration: underline;
+}
+@media (hover: hover) {
+  .grid-item__guidelines:hover,
+  .grid-item__legal:hover {
+    opacity: 1;
+    text-decoration: underline;
+  }
+}
+
 .grid-item__legal::before {
   content: '';
   background-image: var(--asset-svg-legal);
@@ -592,92 +605,35 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   margin: 0.05rem 0.2rem 0.05rem 0;
   width: 0.9rem;
 }
-.grid-item__legal:focus {
-  opacity: 1;
-  text-decoration: underline;
-}
-@media (hover: hover) {
-  .grid-item__legal:hover {
-    opacity: 1;
-    text-decoration: underline;
-  }
-}
 
 .grid-item__footer {
-  border-top: 1px solid var(--color-grid-item-divider);
-  background-color: var(--color-background);
+  align-items: stretch;
+  align-self: stretch;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   justify-content: flex-start;
-  margin: 0.5rem 0 0;
-  padding: 0.8rem 1rem;
-  align-self: stretch;
+  margin-top: 0.4rem;
 }
-
-.grid-item__preview {
-  cursor: default; /* This should function as decoration when JS is disabled */
-  fill: var(--color-svg-default);
-  flex-grow: 0;
-  height: 3rem;
-  margin-right: 1rem;
-  position: relative;
-  width: 3rem;
-}
-.grid-item__preview::before {
-  background-color: var(--color-background-transparent);
-  background-size: 1.7rem 1.7rem;
-  content: '';
-  cursor: pointer;
-  display: none;
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-.grid-item__preview:not(:disabled).copied::before,
-.grid-item__preview:not(:disabled):focus::before {
-  display: block;
-}
-@media (hover: hover) {
-  .grid-item__preview:not(:disabled):hover::before {
-    display: block;
-  }
-}
-
-.grid-item__downloads {
-  display: flex;
-  flex-direction: column;
-}
-.grid-item__downloads h3 {
-  font-family: 'Roboto Mono', monospace;
-  font-size: 0.95rem;
-  margin-bottom: 0.2rem;
-}
-
-.grid-item__button-row {
-  display: flex;
-  flex-direction: row;
-}
-
 .grid-item__button {
-  border: 0.1rem solid var(--color-button-hover);
-  border-radius: var(--border-radius-small);
-  padding: 0.3rem 0.4rem;
-  margin: 0 0.4rem;
+  border-top: 1px solid var(--color-grid-item-divider);
+  background-color: var(--color-background);
+  color: var(--color-button-active);
+  flex-grow: 1;
   font-family: 'Roboto Mono', monospace;
   font-size: 0.75rem;
   font-weight: 600;
-}
-.grid-item__button:first-child {
-  margin-left: 0;
+  outline: none;
+  padding: 8px;
+  text-align: center;
 }
 .grid-item__button:focus,
 .grid-item__button:hover {
   background: var(--color-button-hover);
   color: var(--color-button-text-hover);
 }
+
+/* Carbon ads */
 
 #carbonads {
   align-items: center;

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -34,7 +34,7 @@ describe('Copy', () => {
     }
 
     document.querySelectorAll.mockImplementation((query) => {
-      if (query === '.grid-item__color') {
+      if (query === '.copy-color') {
         return $colorButtons;
       }
 
@@ -79,7 +79,7 @@ describe('Copy', () => {
     }
 
     document.querySelectorAll.mockImplementation((query) => {
-      if (query === '.grid-item__preview') {
+      if (query === '.copy-svg') {
         return $svgButtons;
       }
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -294,7 +294,7 @@ describe('Ordering', () => {
     // Items are ordered using the CSS property `order`...
     await expect(page).toClick('#order-color');
 
-    const $gridItems = await page.$$('.grid-item__color');
+    const $gridItems = await page.$$('.copy-color');
     for (let i = 0; i < $gridItems.length; i++) {
       const $gridItem = $gridItems[i];
       const hex = hexes[i];
@@ -396,23 +396,23 @@ describe('Grid item', () => {
   });
 
   it('has the color value button enabled', async () => {
-    const $previewButton = await page.$('button.grid-item__color');
+    const $previewButton = await page.$('button.copy-color');
     expect(await isDisabled($previewButton)).toBeFalsy();
   });
 
   it('copies the hex value when it is clicked', async () => {
-    await expect(page).toClick('button.grid-item__color');
+    await expect(page).toClick('button.copy-color');
     const clipboardValue = await getClipboardValue(page);
     expect(clipboardValue).toMatch(COLOR_REGEX);
   });
 
   it('has the SVG preview button enabled', async () => {
-    const $previewButton = await page.$('button.grid-item__preview');
+    const $previewButton = await page.$('button.copy-svg');
     expect(await isDisabled($previewButton)).toBeFalsy();
   });
 
   it('copies the SVG value when the preview is clicked', async () => {
-    await expect(page).toClick('button.grid-item__preview');
+    await expect(page).toClick('button.copy-svg');
     const clipboardValue = await getClipboardValue(page);
     expect(clipboardValue).toMatch(SVG_REGEX);
   });
@@ -460,12 +460,12 @@ describe('JavaScript disabled', () => {
   });
 
   it('has the color value button disabled', async () => {
-    const $colorButton = await page.$('button.grid-item__color');
+    const $colorButton = await page.$('button.copy-color');
     expect(await isDisabled($colorButton)).toBeTruthy();
   });
 
   it('has the SVG preview button disabled', async () => {
-    const $previewButton = await page.$('button.grid-item__preview');
+    const $previewButton = await page.$('button.copy-svg');
     expect(await isDisabled($previewButton)).toBeTruthy();
   });
 


### PR DESCRIPTION
Closes #25 

### Description

Inspired by [@PeterShaggyNoble design "mocks"](https://user-images.githubusercontent.com/3742559/117554029-5fbf1880-b055-11eb-9153-d1ae4f922dd9.png), this brings the redesigned website a bit closer to the old website.

### Preview

| Current | New |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3742559/117554224-977a9000-b056-11eb-8fec-2fd8be4c726d.png) | ![image](https://user-images.githubusercontent.com/3742559/117554210-82056600-b056-11eb-829c-b8ac86d30641.png) |

### Discussion

The motivation for these changes are based on [feedback we received](https://github.com/simple-icons/simple-icons/discussions/4865) and, in particular, the following points:

- The "logo in the background" looked nice to some and ugly to others. Ultimately, it was there just for some visual flare and it can thus be argued that it was just "wasting space". Hence, we decided go back to the layout where the SVG is displayed prominently at the top of the card.
- The "brand guidelines" and "license" links are now displayed between the SVG and the title, this makes the titles align better.
- The card footer is now much simpler and smaller, just displaying the color and download options. For the record, while I would be okay switching/using icons for the download buttons I did not do that here to avoid discussion, what is currently in this PR most closely resembles the current live redesign.

Some suggestions to those reviewing this PR: in the interest of switching our domain to the new design I think we should largely avoid focussing on details such as spacing and size here - if you're concerned about anything like this I suggest to open an issue (after this PR has been merged) for that instead.

Also, after this is merged we can get https://github.com/simple-icons/simple-icons-website/pull/55 merged as it relies on the removal of the "logo in the background".