### PR TITLE
Update header links

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -39,6 +39,10 @@ html
           a(href="https://www.npmjs.com/package/simple-icons" rel="noopener") NPM
         li(class="header__list-item")
           a(href="https://packagist.org/packages/simple-icons/simple-icons" rel="noopener") Packagist
+        li(class="header__list-item")
+          a(href="https://www.jsdelivr.com/package/npm/simple-icons" rel="noopener") JSDelivr
+        li(class="header__list-item")
+          a(href="https://unpkg.com/browse/simple-icons/" rel="noopener") Unpkg
       h1(class="header__title") Simple Icons
       p(class="header__description") #{iconCount} Free #[abbr(title="Scalable Vector Graphic") SVG] icons for popular brands
 

--- a/public/index.pug
+++ b/public/index.pug
@@ -39,8 +39,6 @@ html
           a(href="https://www.npmjs.com/package/simple-icons" rel="noopener") NPM
         li(class="header__list-item")
           a(href="https://packagist.org/packages/simple-icons/simple-icons" rel="noopener") Packagist
-        li(class="header__list-item")
-          a(href="https://github.com/simple-icons/simple-icons#readme" rel="noopener") About
       h1(class="header__title") Simple Icons
       p(class="header__description") #{iconCount} Free #[abbr(title="Scalable Vector Graphic") SVG] icons for popular brands
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -106,8 +106,12 @@ describe('External links', () => {
     await expect(page).toClick('a', { text: 'Packagist' });
   });
 
-  it('is possible to click the about link', async () => {
-    await expect(page).toClick('a', { text: 'About' });
+  it('is possible to click the JSDelivr link', async () => {
+    await expect(page).toClick('a', { text: 'JSDelivr' });
+  });
+
+  it('is possible to click the Unpkg link', async () => {
+    await expect(page).toClick('a', { text: 'Unpkg' });
   });
 });
 


### PR DESCRIPTION
- Closes #27: The "About" link has been removed.
- Closes #59: Links to both JSDeliver and Unpkg have been added.

### Preview

| Before | After |
| --- | --- |
| ![preview links after](https://user-images.githubusercontent.com/3742559/118166785-353ed800-b426-11eb-8dd7-52749647fb54.png) | ![preview links after](https://user-images.githubusercontent.com/3742559/118166675-0fb1ce80-b426-11eb-8f85-28913b67cc3d.png) |
