### PR TITLE
Set up scheduled analysis

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,7 @@
+name: Simple Icons website CodeQL config
+
+queries:
+  - uses: security-extended
+
+paths:
+  - public/

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,39 @@
+name: Analysis
+on:
+  push:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          config-file: ./.github/codeql.yml
+          languages: javascript
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+  lighthouse:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+      - name: Install dependencies
+        run: npm ci
+      - name: Build website
+        run: npm run build
+      - name: Run Lighthouse
+        uses: treosh/lighthouse-ci-action@v7
+        with:
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,6 +1,5 @@
 name: Analysis
 on:
-  push:
   schedule:
     - cron: '0 0 1 * *'
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,12 @@
+{
+  "ci": {
+    "collect": {
+      "settings": {
+        "preset": "desktop"
+      },
+      "collect": {
+        "staticDistDir": "./_site"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Suggestion to add analysis of the repository/website through a scheduled GitHub Actions Workflow. Currently I set it to run once a month and to run:

- [A Lighthouse scan](https://github.com/marketplace/actions/lighthouse-ci-action), which will report on the "health" of the website, things such as performance, a11y, and SEO. This can be pretty useful to find improvements for the website, though our performance score is incredibly bad because of our large HTML.

  I currently configured it to just upload the results as an artifact so that anyone can look at it without having to perform the scan themselves. To be fair, anyone can do that pretty easily if they have Chrome/ium installed.
- [A CodeQL scan](https://github.com/github/codeql#readme), which runs some basic security queries on the (static) source and can report potential vulnerabilities. I think it's unlikely it will report something interesting for us, but it could still be worth it.

I'm opening this as a Pull Request because I'm not sure if everyone sees value in it. As per the above, Lighthouse is pretty easy for anyone to use and CodeQL is unlikely to find anything interesting. So if no one is interested in this we can just close it :slightly_smiling_face: 