### PR TITLE
Add content-visibility to grid items

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -472,6 +472,8 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   background-color: var(--color-background-card);
   border-radius: var(--border-radius-large);
   box-shadow: 0px 0px 3px 0px var(--color-shadows);
+  contain-intrinsic-size: 0 11.25rem;
+  content-visibility: auto;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
Closes #67

---

Adds the new [`content-visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility) CSS property to grid items and use [`content-intrinsic-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size) to define a "standard" height before the grid item is rendered - details below. From some local testing it seems this improves the loading speed by ~30%. However, browser support is still limited. On the positive side, this has no negative effects on browsers that don't support it (yet).

### Preview

https://user-images.githubusercontent.com/3742559/119278344-f5959e80-bc24-11eb-8356-2e3c05239b2f.mp4

### `content-intrinsic-size`

The `content-intrinsic-size` is currently set to 11.25rem (i.e. 180px at a root font-size of 16px, which seems to be the default of browsers with the existing CSS) which is roughly the height of a grid item. Small grid items are ~170px (short title, no guidelines/license), medium grid items are ~190px (long title, no guidelines/license). Some large grid items, ~220px (short title, guidelines and license), exist but they're not very common so I ignored them for now.

Both setting it too low and too high looks weird as that will be the size of the grid items before their content is loaded - the short time where they're completely blank in the preview above. Getting this value right is pretty important I think.