### PR TITLE
Add fallback fonts and use CSS vars for font families

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -9,6 +9,9 @@
   height: 100%;
   min-width: 280px;
 
+  --font-family-text: 'Open Sans', 'Arial', 'Helvetica', sans-serif;
+  --font-family-stylized: 'Roboto Mono', 'Consolas', 'Courier New', monospace;
+
   --color-twitter: rgb(29, 161, 242);
   --color-twitter-hover: rgba(29, 161, 242, 0.8);
   --side-offset: 6rem;
@@ -222,7 +225,7 @@ a {
 }
 
 .header__title {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 1.7rem;
   font-weight: 600;
   flex-basis: 40%;
@@ -230,7 +233,7 @@ a {
 }
 
 .header__description {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.9rem;
   margin: 0.2rem 0;
 }
@@ -253,7 +256,7 @@ a {
 }
 
 .header__list-item {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 1rem;
   font-weight: 600;
   margin: 0 0.7rem;
@@ -329,7 +332,7 @@ a {
 }
 
 .control-field__title {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 1rem;
   font-weight: 400;
   line-height: 1rem;
@@ -358,7 +361,7 @@ body.no-js .control-field__title {
 }
 
 .control__input {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   outline: 0;
   padding: 0.4rem 2rem 0.4rem 0.8rem;
   width: 100%;
@@ -413,7 +416,7 @@ body.no-js .control-field__title {
 .search #search-clear {
   cursor: pointer;
   display: inline;
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 1.5rem;
   line-height: 2.3rem;
   padding: 0 12px;
@@ -452,7 +455,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
 
 .control noscript {
   position: absolute;
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-style: italic;
   top: -2rem;
 }
@@ -475,7 +478,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   margin: 0 0.4rem;
 }
 .grid-item--if-empty p {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.9rem;
 }
 .grid-item--if-empty a {
@@ -517,7 +520,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
 }
 
 .grid-item__title {
-  font-family: 'Open Sans', sans-serif;
+  font-family: var(--font-family-text);
   font-size: 1.2rem;
   font-weight: 600;
   line-height: 1.5rem;
@@ -546,7 +549,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   color: var(--color-text-default);
   display: flex;
   flex-direction: row;
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.8rem;
   line-height: 1rem;
   margin: 0.3rem 0;
@@ -578,7 +581,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   border-top: 1px solid var(--color-grid-item-divider);
   color: #000;
   flex-grow: 2;
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 1px;
@@ -595,7 +598,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   background-color: var(--color-background);
   color: var(--color-button-active);
   flex-grow: 1;
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.75rem;
   font-weight: 600;
   outline: none;
@@ -676,7 +679,7 @@ body.order-by-relevance .grid-item {
   align-items: center;
   background-color: var(--color-background);
   display: flex;
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.9rem;
   flex-wrap: wrap;
   justify-content: space-between;
@@ -801,7 +804,7 @@ body.order-by-relevance .grid-item {
 /* Temporary feedback banner */
 
 .banner-feedback {
-  font-family: 'Roboto Mono', monospace;
+  font-family: var(--font-family-stylized);
   font-size: 0.8rem;
   padding: 8px var(--side-offset);
 }

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -10,7 +10,8 @@
   min-width: 280px;
 
   --font-family-text: 'Open Sans', 'Arial', 'Helvetica', sans-serif;
-  --font-family-stylized: 'Roboto Mono', 'Consolas', 'Courier New', monospace;
+  --font-family-stylized: 'Roboto Mono', 'DejaVu Sans Mono', 'Consolas',
+    monospace;
 
   --color-twitter: rgb(29, 161, 242);
   --color-twitter-hover: rgba(29, 161, 242, 0.8);


### PR DESCRIPTION
Closes #71

This sets:

- [DejaVu Sans Mono](https://www.fontsquirrel.com/fonts/dejavu-sans-mono) and [Consolas](https://www.fonts.com/font/microsoft-corporation/consolas?QueryFontType=Web) as explicit fallback fonts for [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono).

  I also considered [Lucida Console](https://www.fonts.com/font/monotype/lucida-console?QueryFontType=Web) and [Courier New](https://fonts.google.com/?query=courier+new) but personally found it too different from [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono).
- [Arial](https://www.fonts.com/font/monotype/arial?QueryFontType=Web) and [Helvetica](https://www.fonts.com/font/linotype/helvetica?QueryFontType=Web) as explicit fallback fonts for [Open Sans](https://fonts.google.com/specimen/Open+Sans).

  I also considered [Verdana](https://www.fonts.com/font/microsoft-corporation/verdana?QueryFontType=Web) and [Trebuchet MS](https://www.fonts.com/font/microsoft-corporation/trebuchet-ms?QueryFontType=Web) but personally found it too different from [Open Sans](https://fonts.google.com/specimen/Open+Sans).

Suggestions for additional or different fallbacks are welcome :slightly_smiling_face: 

Additionally, this also converts the individual font-family definitions into CSS variables.