### PR TITLE
Fix Parameter of Publish Website Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build Website
         run: npm run build
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
           folder: _site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: _site
-          SINGLE_COMMIT: true
+          branch: gh-pages
+          folder: _site
+          single-commit: true


### PR DESCRIPTION
`single-commit` option is supposed to have a dash `-` rather than underscore `_`. [Docs](https://github.com/JamesIves/github-pages-deploy-action). 
![image](https://user-images.githubusercontent.com/59678453/121798212-eb3e4300-cbd9-11eb-9c13-e19523c35fc8.png)
