### PR TITLE
Setup automated manual install of simple-icons-pdf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9239,10 +9239,6 @@
       "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-5.3.0.tgz",
       "integrity": "sha512-PXtQTAqYjF04jSLQAQ1O2u63Uz0lB75g9+DuR6xyS8cRs4NLterHcbC/HDQ9QGexmymfJDMip1ptrkanrOvjYw=="
     },
-    "simple-icons-pdf": {
-      "version": "https://github.com/simple-icons/simple-icons-pdf/tarball/master",
-      "integrity": "sha512-gHrA237Cm9vdpSIFSckp7oK8SxAhm9RYtyrN5dqk6Lt7I0XHwKC9buouG+uznmeumaIbk0flCwK5NyohUBRX8A=="
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -19,17 +19,18 @@
     "clean": "rm -rf _site tests/_artifacts",
     "format": "prettier --write --single-quote --trailing-comma all .",
     "lint": "prettier --check --single-quote --trailing-comma all .",
-    "postinstall": "is-ci || husky install",
+    "postinstall": "run-s setup:husky setup:pdfs",
     "serve": "anywhere -p 8080 -d ./_site",
     "serve:watch": "run-p build:watch serve",
+    "setup:husky": "is-ci || husky install",
+    "setup:pdfs": "npm install https://github.com/simple-icons/simple-icons-pdf/tarball/master --no-save",
     "test": "npm run test:unit",
     "test:all": "cross-env TEST_ENV=all jest",
     "test:integration": "cross-env TEST_ENV=integration jest",
     "test:unit": "cross-env TEST_ENV=unit jest"
   },
   "dependencies": {
-    "simple-icons": "5.3.0",
-    "simple-icons-pdf": "https://github.com/simple-icons/simple-icons-pdf/tarball/master"
+    "simple-icons": "5.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.14.3",


### PR DESCRIPTION
Relates to https://github.com/simple-icons/simple-icons/pull/5804, https://github.com/simple-icons/simple-icons-pdf/pull/2

This removes `simple-icons-pdf` as a project dependency, and instead adds it as a post-install script install (using `--no-save`).  This ensures we always get the latest PDFs available on the [simple-icons-pdf `master` branch](https://github.com/simple-icons/simple-icons-pdf/tree/master/) without having to worry about checksum mismatched.

In the long term we may want to switch from a repository-based installation of the `simple-icons-pdf` project, but until we do that I think this is a decent solution.