### PR TITLE
Update search input

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -52,7 +52,7 @@ html(lang="en-US")
             input(
               id="search-input"
               class="control__input"
-              type="text"
+              type="search"
               placeholder="Search by brand..."
               disabled
             )

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -61,7 +61,7 @@ export default function initSearch(history, document, ordering, domUtils) {
       search(value);
     }),
   );
-  $searchInput.addEventListener('search', () => {
+  $searchInput.addEventListener('change', () => {
     $searchInput.blur();
   });
 

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -61,6 +61,9 @@ export default function initSearch(history, document, ordering, domUtils) {
       search(value);
     }),
   );
+  $searchInput.addEventListener('search', () => {
+    $searchInput.blur();
+  });
 
   $searchClear.addEventListener('click', (event) => {
     event.preventDefault();

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -429,6 +429,19 @@ body.no-js .control-field__title {
   background-color: transparent;
 }
 
+input[type='search']::-webkit-search-decoration,
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-results-button,
+input[type='search']::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+input[type='search']::-ms-clear,
+input[type='search']::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 /* Control - order */
 
 body.order-alphabetically #order-alpha,

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -158,6 +158,21 @@ describe('Search', () => {
         done();
       }, 500);
     });
+
+    it('works if search event is fired', () => {
+      expect($searchInput.addEventListener).toHaveBeenCalledWith(
+        'search',
+        expect.any(Function),
+      );
+
+      const searchListener = inputEventListeners.get('search');
+      const event = newEventMock();
+
+      $searchInput.value = 'Hello world!';
+      searchListener(event);
+
+      expect($searchInput.blur).toHaveBeenCalled();
+    });
   });
 
   describe('URL query', () => {

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -159,13 +159,13 @@ describe('Search', () => {
       }, 500);
     });
 
-    it('works if search event is fired', () => {
+    it('works if change event is fired', () => {
       expect($searchInput.addEventListener).toHaveBeenCalledWith(
-        'search',
+        'change',
         expect.any(Function),
       );
 
-      const searchListener = inputEventListeners.get('search');
+      const searchListener = inputEventListeners.get('change');
       const event = newEventMock();
 
       $searchInput.value = 'Hello world!';


### PR DESCRIPTION
Part of the effort started in #83, but separated as I expect this will take some more discussion than that Pull Request requires.

This changes the input type of the search bar from `"text"` to `"search"`. This makes semantic sense and allows us to easily hide the keyboard on mobile devices when the users presses the "search" button on their keyboard by adding an event listener for the `"change"` event.

However, there's a catch: some browsers automatically add a button to search inputs to clear it (notably Chrome), while other don't (notably Firefox, desktop 78.0.2; mobile 89.1.1). Does anyone has suggestions or opinions for solving this problem (@simple-icons/maintainers)? Can we remove/hide it in browsers like Chrome? Or should we just drop it from other browsers?