### PR TITLE
Fix missing icons bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5199,16 +5199,6 @@
         "pend": "~1.2.0"
       }
     },
-    "file-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7779,17 +7769,6 @@
       "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
       "dev": true
     },
-    "loader-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      }
-    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -9819,16 +9798,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "svg-url-loader": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/svg-url-loader/-/svg-url-loader-7.1.1.tgz",
-      "integrity": "sha512-NlsMCePODm7FQhU9aEZyGLPx5Xe1QRI1cSEUE6vTq5LJc9l9pStagvXoEIyZ9O3r00w6G3+Wbkimb+SC3DI/Aw==",
-      "dev": true,
-      "requires": {
-        "file-loader": "~6.2.0",
-        "loader-utils": "~2.0.0"
       }
     },
     "svgo": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "pug": "3.0.2",
     "pug-loader": "2.4.0",
     "puppeteer": "10.2.0",
-    "svg-url-loader": "7.1.1",
     "webpack": "5.49.0",
     "webpack-cli": "4.7.2"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,7 @@ module.exports = {
       },
       {
         test: /\.svg$/i,
-        use: ['svg-url-loader'],
+        type: 'asset/inline',
       },
     ],
   },


### PR DESCRIPTION
Fix the bug where UI icons are missing, closing #97.

This bug was caused by a change introduced in the upgrade from mini-css-extract-plugin v1 to v2. As per its [v2 release notes](https://github.com/webpack-contrib/mini-css-extract-plugin/releases/tag/v2.0.0), "x-loader"s are no longer supported and we should instead use ["Asset Modules"](https://webpack.js.org/guides/asset-modules/). Hence, I updated the importing of SVGs to follow the examples for SVGs in webpack's docs on asset modules.
