### PR TITLE
Set save-exact in .npmrc to enforce --save-exact

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
I just learned about the [`save-exact` option](https://docs.npmjs.com/cli/v7/using-npm/config#save-exact) while working on #108 and figured we can add it to the `.npmrc` file to enforce that dependencies are always installed at an exact version - which is how we usually want to install dependencies in the simple-icons organization.

If this gets merged here, we probably want to apply this to all the repositories.
