### PR TITLE
Remove JavaScript blurs

### DIFF
--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -29,17 +29,14 @@ export default function initColorScheme(document, storage) {
   $colorSchemeDark.addEventListener('click', (event) => {
     event.preventDefault();
     selectColorScheme(COLOR_SCHEME_DARK);
-    $colorSchemeDark.blur();
   });
   $colorSchemeLight.addEventListener('click', (event) => {
     event.preventDefault();
     selectColorScheme(COLOR_SCHEME_LIGHT);
-    $colorSchemeLight.blur();
   });
   $colorSchemeSystem.addEventListener('click', (event) => {
     event.preventDefault();
     selectColorScheme(COLOR_SCHEME_SYSTEM);
-    $colorSchemeSystem.blur();
   });
 
   function selectColorScheme(selected) {

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -16,7 +16,6 @@ export default function initCopyButtons(window, document, navigator) {
       event.preventDefault();
 
       const value = $colorButton.innerHTML;
-      $colorButton.blur();
       copyValue(value);
       setCopied($colorButton);
     });
@@ -32,7 +31,6 @@ export default function initCopyButtons(window, document, navigator) {
       const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
 
       const value = window.atob(base64Svg);
-      $svgButton.blur();
       copyValue(value);
       setCopied($svgButton);
     });
@@ -45,7 +43,6 @@ export default function initCopyButtons(window, document, navigator) {
       $copyInput.value = value;
       $copyInput.select();
       document.execCommand('copy');
-      $copyInput.blur();
     }
   }
 }

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -31,17 +31,14 @@ export default function initOrdering(document, storage) {
   $orderAlphabetically.addEventListener('click', (event) => {
     event.preventDefault();
     selectOrdering(ORDER_ALPHABETICALLY);
-    $orderAlphabetically.blur();
   });
   $orderByColor.addEventListener('click', (event) => {
     event.preventDefault();
     selectOrdering(ORDER_BY_COLOR);
-    $orderByColor.blur();
   });
   $orderByRelevance.addEventListener('click', (event) => {
     event.preventDefault();
     selectOrdering(ORDER_BY_RELEVANCE);
-    $orderByRelevance.blur();
   });
 
   function currentOrderingIs(value) {

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -61,9 +61,6 @@ export default function initSearch(history, document, ordering, domUtils) {
       search(value);
     }),
   );
-  $searchInput.addEventListener('change', () => {
-    $searchInput.blur();
-  });
 
   $searchClear.addEventListener('click', (event) => {
     event.preventDefault();

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -46,7 +46,6 @@ describe('Color scheme', () => {
     const event = newEventMock();
     clickListener(event);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect($colorSchemeDark.blur).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'dark',
@@ -85,7 +84,6 @@ describe('Color scheme', () => {
     const event = newEventMock();
     clickListener(event);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect($colorSchemeLight.blur).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'light',
@@ -124,7 +122,6 @@ describe('Color scheme', () => {
     const event = newEventMock();
     clickListener(event);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect($colorSchemeSystem.blur).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'system',

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -62,7 +62,6 @@ describe('Copy', () => {
       const event = newEventMock();
       clickListener(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
-      expect($colorButton.blur).toHaveBeenCalledTimes(1);
       expect($colorButton.classList.add).toHaveBeenCalledWith('copied');
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
         $colorButton.innerHTML,
@@ -118,7 +117,6 @@ describe('Copy', () => {
       const event = newEventMock();
       clickListener(event);
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
-      expect($svgButton.blur).toHaveBeenCalledTimes(1);
       expect($svgButton.classList.add).toHaveBeenCalledWith('copied');
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(rawSvg);
     }

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -46,7 +46,6 @@ describe('Ordering', () => {
     const event = newEventMock();
     clickListener(event);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect($orderAlphabetically.blur).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
       'alphabetically',
@@ -85,7 +84,6 @@ describe('Ordering', () => {
     const event = newEventMock();
     clickListener(event);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect($orderByColor.blur).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
       'color',
@@ -120,7 +118,6 @@ describe('Ordering', () => {
     const event = newEventMock();
     clickListener(event);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect($orderByRelevance.blur).toHaveBeenCalledTimes(1);
   });
 
   it('uses alphabetical ordering if no value is stored', () => {

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -156,21 +156,6 @@ describe('Search', () => {
 
       done();
     });
-
-    it('works if change event is fired', () => {
-      expect($searchInput.addEventListener).toHaveBeenCalledWith(
-        'change',
-        expect.any(Function),
-      );
-
-      const searchListener = inputEventListeners.get('change');
-      const event = newEventMock();
-
-      $searchInput.value = 'Hello world!';
-      searchListener(event);
-
-      expect($searchInput.blur).toHaveBeenCalled();
-    });
   });
 
   describe('URL query', () => {


### PR DESCRIPTION
Remove the use of `.blur()` to improve a11y, in particular when it comes to resetting the tabindex when clicking the control buttons.