### PR TITLE
Improve accessability of button focus state by making it different from the active state

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -407,10 +407,8 @@ body.no-js .control-field__title {
 }
 .control__button:not(:disabled):focus,
 .control__button:not(:disabled):hover {
-  background-color: var(--color-button-hover) !important;
-  border-color: var(--color-button-hover) !important;
+  box-shadow: 0 0 3px 0 var(--color-shadows);
   cursor: pointer;
-  fill: var(--color-background);
 }
 
 /* Control - disabled */


### PR DESCRIPTION
Before the active state of the control buttons was identical to their active state, this could make it a bit difficult to tell which element was currently focused when tabbing through the page. In this PR I add a separate styling for when the control buttons are focused, inspired by the focus styling of the `<input>`.

### Before

https://user-images.githubusercontent.com/3742559/138762663-3be858ab-f76a-45f2-8ad2-e8937438d7cf.mp4

### After 

https://user-images.githubusercontent.com/3742559/138762556-2c8e9edb-4bc6-42a8-b20b-23f35938e647.mp4 