### PR TITLE
Adding query parameters for ordering and color scheme

### DIFF
--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -1,4 +1,10 @@
 import { STORAGE_KEY_COLOR_SCHEME } from './storage.js';
+import {
+  paramFromURL,
+  COLOR_PARAMETER,
+  setParameterInURL,
+  initControlButton,
+} from './utils.js';
 
 const COLOR_SCHEME_DARK = 'dark';
 const COLOR_SCHEME_LIGHT = 'light';
@@ -6,55 +12,46 @@ const COLOR_SCHEME_SYSTEM = 'system';
 
 const DEFAULT_COLOR_SCHEME = COLOR_SCHEME_SYSTEM;
 
-const CLASS_DARK_MODE = 'dark';
-const CLASS_LIGHT_MODE = 'light';
-
 export default function initColorScheme(document, storage) {
   let activeColorScheme = DEFAULT_COLOR_SCHEME;
 
   const $body = document.querySelector('body');
-  const $colorSchemeDark = document.getElementById('color-scheme-dark');
-  const $colorSchemeLight = document.getElementById('color-scheme-light');
-  const $colorSchemeSystem = document.getElementById('color-scheme-system');
-
-  $colorSchemeDark.disabled = false;
-  $colorSchemeLight.disabled = false;
-  $colorSchemeSystem.disabled = false;
-
-  if (storage.hasItem(STORAGE_KEY_COLOR_SCHEME)) {
-    const storedColorScheme = storage.getItem(STORAGE_KEY_COLOR_SCHEME);
-    selectColorScheme(storedColorScheme);
-  }
-
-  $colorSchemeDark.addEventListener('click', (event) => {
-    event.preventDefault();
-    selectColorScheme(COLOR_SCHEME_DARK);
-  });
-  $colorSchemeLight.addEventListener('click', (event) => {
-    event.preventDefault();
-    selectColorScheme(COLOR_SCHEME_LIGHT);
-  });
-  $colorSchemeSystem.addEventListener('click', (event) => {
-    event.preventDefault();
-    selectColorScheme(COLOR_SCHEME_SYSTEM);
-  });
 
   function selectColorScheme(selected) {
     if (selected === activeColorScheme) {
       return;
     }
 
-    if (selected === COLOR_SCHEME_DARK) {
-      $body.classList.add(CLASS_DARK_MODE);
-      $body.classList.remove(CLASS_LIGHT_MODE);
-    } else if (selected === COLOR_SCHEME_LIGHT) {
-      $body.classList.add(CLASS_LIGHT_MODE);
-      $body.classList.remove(CLASS_DARK_MODE);
-    } else {
-      $body.classList.remove(CLASS_DARK_MODE, CLASS_LIGHT_MODE);
-    }
+    $body.classList.remove(
+      COLOR_SCHEME_DARK,
+      COLOR_SCHEME_LIGHT,
+      COLOR_SCHEME_SYSTEM,
+    );
+
+    $body.classList.add(selected);
 
     storage.setItem(STORAGE_KEY_COLOR_SCHEME, selected);
     activeColorScheme = selected;
+    setParameterInURL(COLOR_PARAMETER, selected);
+  }
+
+  initControlButton('color-scheme-dark', COLOR_SCHEME_DARK, selectColorScheme);
+  initControlButton(
+    'color-scheme-light',
+    COLOR_SCHEME_LIGHT,
+    selectColorScheme,
+  );
+  initControlButton(
+    'color-scheme-system',
+    COLOR_SCHEME_SYSTEM,
+    selectColorScheme,
+  );
+
+  const color = paramFromURL(document.location, COLOR_PARAMETER);
+  if (color) {
+    selectColorScheme(color);
+  } else if (storage.hasItem(STORAGE_KEY_COLOR_SCHEME)) {
+    const storedColorScheme = storage.getItem(STORAGE_KEY_COLOR_SCHEME);
+    selectColorScheme(storedColorScheme);
   }
 }

--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -17,7 +17,7 @@ export default function initColorScheme(document, history, storage) {
 
   const $body = document.querySelector('body');
 
-  function selectColorScheme(selected) {
+  function selectColorScheme(selected, persistLocally = true) {
     if (selected === activeColorScheme) {
       return;
     }
@@ -30,9 +30,8 @@ export default function initColorScheme(document, history, storage) {
 
     $body.classList.add(selected);
 
-    storage.setItem(STORAGE_KEY_COLOR_SCHEME, selected);
     activeColorScheme = selected;
-    setParameterInURL(document, history, COLOR_PARAMETER, selected);
+    if (persistLocally) storage.setItem(STORAGE_KEY_COLOR_SCHEME, selected);
   }
 
   initControlButton(
@@ -56,7 +55,7 @@ export default function initColorScheme(document, history, storage) {
 
   const color = paramFromURL(document.location, COLOR_PARAMETER);
   if (color) {
-    selectColorScheme(color);
+    selectColorScheme(color, false);
   } else if (storage.hasItem(STORAGE_KEY_COLOR_SCHEME)) {
     const storedColorScheme = storage.getItem(STORAGE_KEY_COLOR_SCHEME);
     selectColorScheme(storedColorScheme);

--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -12,7 +12,7 @@ const COLOR_SCHEME_SYSTEM = 'system';
 
 const DEFAULT_COLOR_SCHEME = COLOR_SCHEME_SYSTEM;
 
-export default function initColorScheme(document, storage) {
+export default function initColorScheme(document, history, storage) {
   let activeColorScheme = DEFAULT_COLOR_SCHEME;
 
   const $body = document.querySelector('body');
@@ -32,16 +32,23 @@ export default function initColorScheme(document, storage) {
 
     storage.setItem(STORAGE_KEY_COLOR_SCHEME, selected);
     activeColorScheme = selected;
-    setParameterInURL(COLOR_PARAMETER, selected);
+    setParameterInURL(document, history, COLOR_PARAMETER, selected);
   }
 
-  initControlButton('color-scheme-dark', COLOR_SCHEME_DARK, selectColorScheme);
   initControlButton(
+    document,
+    'color-scheme-dark',
+    COLOR_SCHEME_DARK,
+    selectColorScheme,
+  );
+  initControlButton(
+    document,
     'color-scheme-light',
     COLOR_SCHEME_LIGHT,
     selectColorScheme,
   );
   initControlButton(
+    document,
     'color-scheme-system',
     COLOR_SCHEME_SYSTEM,
     selectColorScheme,

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -11,7 +11,7 @@ import initSearch from './search.js';
 document.body.classList.remove('no-js');
 
 const storage = newStorage(localStorage);
-initColorScheme(document, storage);
+initColorScheme(document, window.history, storage);
 initCopyButtons(window, document, navigator);
-const orderingControls = initOrdering(document, storage);
+const orderingControls = initOrdering(document, window.history, storage);
 initSearch(window.history, document, orderingControls, domUtils);

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -12,7 +12,7 @@ export const ORDER_BY_RELEVANCE = 'order-relevance';
 
 const DEFAULT_ORDERING = ORDER_ALPHABETICALLY;
 
-export default function initOrdering(document, storage) {
+export default function initOrdering(document, history, storage) {
   let activeOrdering = DEFAULT_ORDERING;
   let preferredOrdering = DEFAULT_ORDERING;
 
@@ -22,9 +22,19 @@ export default function initOrdering(document, storage) {
     const storedOrdering = storage.getItem(STORAGE_KEY_ORDERING);
     selectOrdering(storedOrdering);
   }
-  initControlButton('order-alpha', ORDER_ALPHABETICALLY, selectOrdering);
-  initControlButton('order-color', ORDER_BY_COLOR, selectOrdering);
-  initControlButton('order-relevance', ORDER_BY_RELEVANCE, selectOrdering);
+  initControlButton(
+    document,
+    'order-alpha',
+    ORDER_ALPHABETICALLY,
+    selectOrdering,
+  );
+  initControlButton(document, 'order-color', ORDER_BY_COLOR, selectOrdering);
+  initControlButton(
+    document,
+    'order-relevance',
+    ORDER_BY_RELEVANCE,
+    selectOrdering,
+  );
 
   function currentOrderingIs(value) {
     return activeOrdering === value;

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -18,10 +18,14 @@ export default function initOrdering(document, history, storage) {
 
   const $body = document.querySelector('body');
 
-  if (storage.hasItem(STORAGE_KEY_ORDERING)) {
+  const ordering = paramFromURL(document.location, ORDER_PARAMETER);
+  if (ordering) {
+    selectOrdering(ordering, false);
+  } else if (storage.hasItem(STORAGE_KEY_ORDERING)) {
     const storedOrdering = storage.getItem(STORAGE_KEY_ORDERING);
     selectOrdering(storedOrdering);
   }
+
   initControlButton(
     document,
     'order-alpha',
@@ -40,7 +44,7 @@ export default function initOrdering(document, history, storage) {
     return activeOrdering === value;
   }
 
-  function selectOrdering(selected) {
+  function selectOrdering(selected, persistLocally = true) {
     if (selected === activeOrdering) {
       return;
     }
@@ -52,10 +56,10 @@ export default function initOrdering(document, history, storage) {
     );
 
     $body.classList.add(selected);
-
     if (selected !== ORDER_BY_RELEVANCE) {
+      console.log(selected);
       preferredOrdering = selected;
-      storage.setItem(STORAGE_KEY_ORDERING, selected);
+      if (persistLocally) storage.setItem(STORAGE_KEY_ORDERING, selected);
     }
 
     activeOrdering = selected;

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -1,45 +1,30 @@
 import { STORAGE_KEY_ORDERING } from './storage.js';
+import {
+  paramFromURL,
+  ORDER_PARAMETER,
+  setParameterInURL,
+  initControlButton,
+} from './utils.js';
 
-export const ORDER_ALPHABETICALLY = 'alphabetically';
-export const ORDER_BY_COLOR = 'color';
-export const ORDER_BY_RELEVANCE = 'relevance';
+export const ORDER_ALPHABETICALLY = 'order-alphabetically';
+export const ORDER_BY_COLOR = 'order-color';
+export const ORDER_BY_RELEVANCE = 'order-relevance';
 
 const DEFAULT_ORDERING = ORDER_ALPHABETICALLY;
-
-const CLASS_ORDER_ALPHABETICALLY = 'order-alphabetically';
-const CLASS_ORDER_BY_COLOR = 'order-by-color';
-const CLASS_ORDER_BY_RELEVANCE = 'order-by-relevance';
 
 export default function initOrdering(document, storage) {
   let activeOrdering = DEFAULT_ORDERING;
   let preferredOrdering = DEFAULT_ORDERING;
 
   const $body = document.querySelector('body');
-  const $orderAlphabetically = document.getElementById('order-alpha');
-  const $orderByColor = document.getElementById('order-color');
-  const $orderByRelevance = document.getElementById('order-relevance');
-
-  $orderAlphabetically.disabled = false;
-  $orderByColor.disabled = false;
-  $orderByRelevance.disabled = false;
 
   if (storage.hasItem(STORAGE_KEY_ORDERING)) {
     const storedOrdering = storage.getItem(STORAGE_KEY_ORDERING);
     selectOrdering(storedOrdering);
   }
-
-  $orderAlphabetically.addEventListener('click', (event) => {
-    event.preventDefault();
-    selectOrdering(ORDER_ALPHABETICALLY);
-  });
-  $orderByColor.addEventListener('click', (event) => {
-    event.preventDefault();
-    selectOrdering(ORDER_BY_COLOR);
-  });
-  $orderByRelevance.addEventListener('click', (event) => {
-    event.preventDefault();
-    selectOrdering(ORDER_BY_RELEVANCE);
-  });
+  initControlButton('order-alpha', ORDER_ALPHABETICALLY, selectOrdering);
+  initControlButton('order-color', ORDER_BY_COLOR, selectOrdering);
+  initControlButton('order-relevance', ORDER_BY_RELEVANCE, selectOrdering);
 
   function currentOrderingIs(value) {
     return activeOrdering === value;
@@ -51,18 +36,12 @@ export default function initOrdering(document, storage) {
     }
 
     $body.classList.remove(
-      CLASS_ORDER_ALPHABETICALLY,
-      CLASS_ORDER_BY_COLOR,
-      CLASS_ORDER_BY_RELEVANCE,
+      ORDER_ALPHABETICALLY,
+      ORDER_BY_COLOR,
+      ORDER_BY_RELEVANCE,
     );
 
-    if (selected === ORDER_ALPHABETICALLY) {
-      $body.classList.add(CLASS_ORDER_ALPHABETICALLY);
-    } else if (selected === ORDER_BY_COLOR) {
-      $body.classList.add(CLASS_ORDER_BY_COLOR);
-    } else if (selected === ORDER_BY_RELEVANCE) {
-      $body.classList.add(CLASS_ORDER_BY_RELEVANCE);
-    }
+    $body.classList.add(selected);
 
     if (selected !== ORDER_BY_RELEVANCE) {
       preferredOrdering = selected;

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -1,17 +1,12 @@
 import { ORDER_BY_RELEVANCE } from './ordering.js';
-import { decodeURIComponent, debounce, normalizeSearchTerm } from './utils.js';
-
-const QUERY_PARAMETER = 'q';
-
-function getQueryFromParameter(location, parameter) {
-  const expr = new RegExp(`[\\?&]${parameter}=([^&#]*)`);
-  const results = expr.exec(location.search);
-  if (results !== null) {
-    return decodeURIComponent(results[1].replace(/\+/g, ' '));
-  }
-
-  return '';
-}
+import {
+  decodeURIComponent,
+  debounce,
+  normalizeSearchTerm,
+  paramFromURL,
+  QUERY_PARAMETER,
+  setParameterInURL,
+} from './utils.js';
 
 function getScore(query, iconName) {
   let score = iconName.length - query.length;
@@ -28,18 +23,6 @@ function getScore(query, iconName) {
   }
 
   return score;
-}
-
-function setSearchQueryInURL(history, path, query) {
-  if (query !== '') {
-    history.replaceState(
-      null,
-      '',
-      `${path}?${QUERY_PARAMETER}=${encodeURIComponent(query)}`,
-    );
-  } else {
-    history.replaceState(null, '', path);
-  }
 }
 
 export default function initSearch(history, document, ordering, domUtils) {
@@ -70,14 +53,13 @@ export default function initSearch(history, document, ordering, domUtils) {
   });
 
   // Load search query if present
-  const query = getQueryFromParameter(document.location, QUERY_PARAMETER);
+  const query = paramFromURL(document.location, QUERY_PARAMETER);
   if (query) {
     $searchInput.value = query;
     search(query);
   }
 
   function search(rawQuery) {
-    setSearchQueryInURL(history, document.location.pathname, rawQuery);
     const query = normalizeSearchTerm(rawQuery);
     if (query !== '') {
       domUtils.showElement($searchClear);
@@ -118,5 +100,7 @@ export default function initSearch(history, document, ordering, domUtils) {
     }
 
     activeQuery = query;
+
+    setParameterInURL(QUERY_PARAMETER, rawQuery);
   }
 }

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -101,6 +101,6 @@ export default function initSearch(history, document, ordering, domUtils) {
 
     activeQuery = query;
 
-    setParameterInURL(QUERY_PARAMETER, rawQuery);
+    setParameterInURL(document, history, QUERY_PARAMETER, rawQuery);
   }
 }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -51,13 +51,13 @@ module.exports = {
     const results = new URLSearchParams(location.search);
     return results ? results.get(parameter) : '';
   },
-  setParameterInURL: function (paramName, paramValue) {
+  setParameterInURL: function (document, history, paramName, paramValue) {
     const url = new URL(document.location.href);
     if (paramValue) url.searchParams.set(paramName, paramValue);
     history.replaceState(null, '', url.href);
   },
 
-  initControlButton: function (id, value, fn) {
+  initControlButton: function (document, id, value, fn) {
     const $button = document.getElementById(id);
     $button.disabled = false;
     $button.addEventListener('click', (event) => {

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -44,4 +44,25 @@ module.exports = {
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '');
   },
+  QUERY_PARAMETER: 'q',
+  COLOR_PARAMETER: 'c',
+  ORDER_PARAMETER: 'o',
+  paramFromURL: function (location, parameter) {
+    const results = new URLSearchParams(location.search);
+    return results ? results.get(parameter) : '';
+  },
+  setParameterInURL: function (paramName, paramValue) {
+    const url = new URL(document.location.href);
+    if (paramValue) url.searchParams.set(paramName, paramValue);
+    history.replaceState(null, '', url.href);
+  },
+
+  initControlButton: function (id, value, fn) {
+    const $button = document.getElementById(id);
+    $button.disabled = false;
+    $button.addEventListener('click', (event) => {
+      event.preventDefault();
+      fn(value);
+    });
+  },
 };

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -470,8 +470,8 @@ input[type='search']::-ms-reveal {
 /* Control - order */
 
 body.order-alphabetically #order-alpha,
-body.order-by-color #order-color,
-body.order-by-relevance #order-relevance {
+body.order-color #order-color,
+body.order-relevance #order-relevance {
   background-color: var(--color-button-active);
   border-color: var(--color-button-active);
   color: var(--color-background);
@@ -705,10 +705,10 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
 
 /* Ordering grid-items */
 
-body.order-by-color .grid-item {
+body.order-color .grid-item {
   order: var(--order-color);
 }
-body.order-by-relevance .grid-item {
+body.order-relevance .grid-item {
   order: var(--order-relevance);
 }
 

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -3,6 +3,7 @@ const {
   newElementMock,
   newEventMock,
 } = require('./mocks/dom.mock.js');
+const { history } = require('./mocks/history.mock.js');
 const { localStorage } = require('./mocks/local-storage.mock.js');
 
 const initColorScheme = require('../public/scripts/color-scheme.js').default;
@@ -32,7 +33,7 @@ describe('Color scheme', () => {
       return newElementMock(query);
     });
 
-    initColorScheme(document, localStorage);
+    initColorScheme(document, history, localStorage);
     expect(document.getElementById).toHaveBeenCalledWith('color-scheme-dark');
     expect($colorSchemeDark.disabled).toBe(false);
     expect($colorSchemeDark.addEventListener).toHaveBeenCalledWith(
@@ -70,7 +71,7 @@ describe('Color scheme', () => {
       return newElementMock(query);
     });
 
-    initColorScheme(document, localStorage);
+    initColorScheme(document, history, localStorage);
     expect(document.getElementById).toHaveBeenCalledWith('color-scheme-light');
     expect($colorSchemeLight.disabled).toBe(false);
     expect($colorSchemeLight.addEventListener).toHaveBeenCalledWith(
@@ -108,7 +109,7 @@ describe('Color scheme', () => {
       return newElementMock(query);
     });
 
-    initColorScheme(document, localStorage);
+    initColorScheme(document, history, localStorage);
     expect(document.getElementById).toHaveBeenCalledWith('color-scheme-system');
     expect($colorSchemeSystem.disabled).toBe(false);
     expect($colorSchemeSystem.addEventListener).toHaveBeenCalledWith(
@@ -129,7 +130,7 @@ describe('Color scheme', () => {
   });
 
   it('uses the system color scheme if no value is stored', () => {
-    initColorScheme(document, localStorage);
+    initColorScheme(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(localStorage.getItem).not.toHaveBeenCalled();
     expect(localStorage.setItem).not.toHaveBeenCalled();
@@ -139,11 +140,15 @@ describe('Color scheme', () => {
     const storedValue = 'dark';
     localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
-    initColorScheme(document, localStorage);
+    initColorScheme(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(document.$body.classList.add).toHaveBeenCalledWith('dark');
-    expect(document.$body.classList.remove).toHaveBeenCalledWith('light');
+    expect(document.$body.classList.remove).toHaveBeenCalledWith(
+      'dark',
+      'light',
+      'system',
+    );
     expect(localStorage.setItem).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
@@ -155,11 +160,15 @@ describe('Color scheme', () => {
     const storedValue = 'light';
     localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
 
-    initColorScheme(document, localStorage);
+    initColorScheme(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(document.$body.classList.add).toHaveBeenCalledWith('light');
-    expect(document.$body.classList.remove).toHaveBeenCalledWith('dark');
+    expect(document.$body.classList.remove).toHaveBeenCalledWith(
+      'dark',
+      'light',
+      'system',
+    );
     expect(localStorage.setItem).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
@@ -170,8 +179,8 @@ describe('Color scheme', () => {
   it('uses the stored value "system"', () => {
     const storedValue = 'system';
     localStorage.__setStoredValueFor(STORAGE_KEY_COLOR_SCHEME, storedValue);
-
-    initColorScheme(document, localStorage);
+    document.location.href = 'https://simpleicons.org';
+    initColorScheme(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_COLOR_SCHEME);
     expect(localStorage.setItem).not.toHaveBeenCalled();

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -161,7 +161,7 @@ describe('Search', () => {
     await $searchInput.type('adobe');
 
     const $body = await page.$('body');
-    expect(await hasClass($body, 'order-by-relevance')).toBeTruthy();
+    expect(await hasClass($body, 'order-relevance')).toBeTruthy();
   });
 
   it('does not show the "no results" message on search', async () => {
@@ -182,7 +182,7 @@ describe('Search', () => {
 
   it.each([
     ['order-alpha', 'order-alphabetically'],
-    ['order-color', 'order-by-color'],
+    ['order-color', 'order-color'],
   ])('switches back to "%s" when the search is removed', async (id, value) => {
     await page.click(`#${id}`);
 
@@ -193,13 +193,13 @@ describe('Search', () => {
     await $searchInput.press('Backspace');
 
     const $body = await page.$('body');
-    expect(await hasClass($body, 'order-by-relevance')).toBeFalsy();
+    expect(await hasClass($body, 'order-relevance')).toBeFalsy();
     expect(await hasClass($body, value)).toBeTruthy();
   });
 
   it.each([
     ['order-alpha', 'order-alphabetically'],
-    ['order-color', 'order-by-color'],
+    ['order-color', 'order-color'],
   ])('switches back to "%s" when search is cleared', async (id, value) => {
     await page.click(`#${id}`);
 
@@ -210,7 +210,7 @@ describe('Search', () => {
     await $searchClear.click();
 
     const $body = await page.$('body');
-    expect(await hasClass($body, 'order-by-relevance')).toBeFalsy();
+    expect(await hasClass($body, 'order-relevance')).toBeFalsy();
     expect(await hasClass($body, value)).toBeTruthy();
   });
 
@@ -285,7 +285,7 @@ describe('Ordering', () => {
     await page.reload();
 
     const $body = await page.$('body');
-    expect(await hasClass($body, 'order-by-color')).toBeTruthy();
+    expect(await hasClass($body, 'order-color')).toBeTruthy();
   });
 
   it('orders grid items alphabetically', async () => {

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -1,10 +1,11 @@
-const PATHNAME = 'https://www.simpleicons.org';
+const PATHNAME = 'https://www.simpleicons.org/';
 
 export const document = {
   getElementById: jest.fn().mockName('document.getElementById'),
   location: {
     pathname: PATHNAME,
     search: '',
+    href: PATHNAME,
   },
   querySelector: jest.fn().mockName('document.querySelector'),
   querySelectorAll: jest.fn().mockName('document.querySelectorAll'),
@@ -18,6 +19,7 @@ export const document = {
     this.getElementById.mockImplementation(newElementMock);
     this.location.pathname = PATHNAME;
     this.location.search = '';
+    this.location.href = PATHNAME;
     this.querySelector.mockReset();
     this.querySelector.mockImplementation((query) => {
       if (query === 'body') {

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -144,7 +144,7 @@ describe('Ordering', () => {
     initOrdering(document, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
-    expect(document.$body.classList.add).toHaveBeenCalledWith('order-by-color');
+    expect(document.$body.classList.add).toHaveBeenCalledWith('order-color');
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
       storedValue,

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -3,6 +3,7 @@ const {
   newElementMock,
   newEventMock,
 } = require('./mocks/dom.mock.js');
+const { history } = require('./mocks/history.mock.js');
 const { localStorage } = require('./mocks/local-storage.mock.js');
 
 const initOrdering = require('../public/scripts/ordering.js').default;
@@ -32,7 +33,7 @@ describe('Ordering', () => {
       return newElementMock(query);
     });
 
-    initOrdering(document, localStorage);
+    initOrdering(document, history, localStorage);
     expect(document.getElementById).toHaveBeenCalledWith('order-alpha');
     expect($orderAlphabetically.disabled).toBe(false);
     expect($orderAlphabetically.addEventListener).toHaveBeenCalledWith(
@@ -48,7 +49,7 @@ describe('Ordering', () => {
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
-      'alphabetically',
+      'order-alphabetically',
     );
   });
 
@@ -70,7 +71,7 @@ describe('Ordering', () => {
       return newElementMock(query);
     });
 
-    initOrdering(document, localStorage);
+    initOrdering(document, history, localStorage);
     expect(document.getElementById).toHaveBeenCalledWith('order-color');
     expect($orderByColor.disabled).toBe(false);
     expect($orderByColor.addEventListener).toHaveBeenCalledWith(
@@ -86,7 +87,7 @@ describe('Ordering', () => {
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
-      'color',
+      'order-color',
     );
   });
 
@@ -106,7 +107,7 @@ describe('Ordering', () => {
       return newElementMock(query);
     });
 
-    initOrdering(document, localStorage);
+    initOrdering(document, history, localStorage);
     expect(document.getElementById).toHaveBeenCalledWith('order-relevance');
     expect($orderByRelevance.disabled).toBe(false);
     expect($orderByRelevance.addEventListener).toHaveBeenCalledWith(
@@ -121,27 +122,27 @@ describe('Ordering', () => {
   });
 
   it('uses alphabetical ordering if no value is stored', () => {
-    initOrdering(document, localStorage);
+    initOrdering(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
     expect(localStorage.getItem).not.toHaveBeenCalled();
     expect(localStorage.setItem).not.toHaveBeenCalled();
   });
 
-  it('uses the stored value "alphabetically"', () => {
-    const storedValue = 'alphabetically';
+  it('uses the stored value "order-alphabetically"', () => {
+    const storedValue = 'order-alphabetically';
     localStorage.__setStoredValueFor(STORAGE_KEY_ORDERING, storedValue);
 
-    initOrdering(document, localStorage);
+    initOrdering(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
-    expect(localStorage.setItem).not.toHaveBeenCalled();
+    expect(localStorage.setItem).not.toHaveBeenCalledWith();
   });
 
-  it('uses the stored value "color"', () => {
-    const storedValue = 'color';
+  it('uses the stored value "order-color"', () => {
+    const storedValue = 'order-color';
     localStorage.__setStoredValueFor(STORAGE_KEY_ORDERING, storedValue);
 
-    initOrdering(document, localStorage);
+    initOrdering(document, history, localStorage);
     expect(localStorage.hasItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
     expect(localStorage.getItem).toHaveBeenCalledWith(STORAGE_KEY_ORDERING);
     expect(document.$body.classList.add).toHaveBeenCalledWith('order-color');


### PR DESCRIPTION
Added request parameters for ordering (o) and color scheme (c).
Required a heavy refactoring of init methods and the corresponding test suites.
I also refactored the parameter parsing functions to use URLSearchParams and URL classes. It makes the code clearer and safer, and they are VanillaJS so no added size to be concerned about.

I've also included an initControlButton function to reduce code duplication across the system. Further refactorings can be applied to reduce the code duplication and size, but those are out of the scope of this ticket.