### PR TITLE
Rewrite test to use `describe.each` instead of `Array.prototype.forEach`

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -98,7 +98,7 @@ describe('External links', () => {
     await page.goto(url.href);
   });
 
-  const menuLinksTitles = [
+  describe.each([
     'Main Repository',
     'npm',
     'Packagist',
@@ -106,13 +106,11 @@ describe('External links', () => {
     'UNPKG (Content Delivery Network)',
     'Open Collective',
     'Legal Disclaimer',
-  ];
-
-  menuLinksTitles.forEach((title) =>
+  ])(`is possible to click menu links`, (title) => {
     it(`is possible to click the link for ${title}`, async () => {
       await expect(page).toClick(`a[title="${title}"]`);
-    }),
-  );
+    });
+  });
 
   it('is possible to click the link for Github repository', async () => {
     const footerRepositoryTitle = 'website repository';


### PR DESCRIPTION
Groups menu links tests inside a `describe` function.

## Output before

```
External links
    ✓ is possible to click the link for Main Repository (385 ms)
    ✓ is possible to click the link for npm (299 ms)
    ✓ is possible to click the link for Packagist (265 ms)
    ✓ is possible to click the link for jsDelivr (Content Delivery Network) (267 ms)
    ✓ is possible to click the link for UNPKG (Content Delivery Network) (283 ms)
    ✓ is possible to click the link for Open Collective (268 ms)
    ✓ is possible to click the link for Legal Disclaimer (282 ms)
    ✓ is possible to click the link for Github repository (270 ms)
```

## Output after

```
  External links
    ✓ is possible to click the link for Github repository (372 ms)
    is possible to click menu links
      ✓ is possible to click the link for Main Repository (398 ms)
      ✓ is possible to click the link for npm (282 ms)
      ✓ is possible to click the link for Packagist (301 ms)
      ✓ is possible to click the link for jsDelivr (Content Delivery Network) (282 ms)
      ✓ is possible to click the link for UNPKG (Content Delivery Network) (282 ms)
      ✓ is possible to click the link for Open Collective (267 ms)
      ✓ is possible to click the link for Legal Disclaimer (499 ms)
```

