### PR TITLE
Add Windows support for `clean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
     "build:watch": "npm run build:dev -- --watch",
-    "clean": "rm -rf _site tests/_artifacts",
+    "clean": "rimraf _site tests/_artifacts",
     "format": "prettier --write .",
     "lint": "prettier --check .",
     "postinstall": "run-s setup:husky setup:pdfs",
@@ -57,6 +57,7 @@
     "pug": "3.0.2",
     "pug-loader": "2.4.0",
     "puppeteer": "10.4.0",
+    "rimraf": "3.0.2",
     "webpack": "5.60.0",
     "webpack-cli": "4.9.1"
   },


### PR DESCRIPTION
The same change [has been included](https://github.com/simple-icons/simple-icons/pull/6450) in simple-icons and simple-icons-pdf repositories. Note that _rimraf_ is already a dependency of _@jest/core_, so this doesn't increments `node_modules` size.