### PR TITLE
Prevent focus on hidden copy `input`

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -177,4 +177,4 @@ html(lang="en-US")
       div(class="footer-repo")
           p.
             #[a(title="website repository" href="https://github.com/simple-icons/simple-icons-website") Made with &#10084; on GitHub]
-    input(id="copy-input" class="hidden" aria-hidden="true")
+    input(id="copy-input" class="hidden" aria-hidden="true" tabindex="-1")


### PR DESCRIPTION
There is a DOM `input` node that can be focused using <kbd>TAB</kbd> key. I've found this bug using the latest lighthouse report and reproduced locally. Adding `tabindex="-1"` resolves it.