### PR TITLE
Prevent focus on `body`

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -25,7 +25,7 @@ html(lang="en-US")
     link(rel="license" href="license.txt")
     link(rel="canonical" href=pageUrl)
 
-  body(class="no-js order-alphabetically")
+  body(class="no-js order-alphabetically" tabindex="-1")
     header(class="header")
       ul(class="header__list")
         li(class="header__list-item")


### PR DESCRIPTION
The `body` DOM node can be focused using <kbd>TAB</kbd> key, but this is not desirable.