### PR TITLE
Pin to NodeJS v12 in "Automated Releases" CI workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,6 +20,10 @@ jobs:
           ref: master
           # Ensure custom credentials are used when pushing
           persist-credentials: false
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
       - name: Update simple-icons
         id: update
         run: |


### PR DESCRIPTION
Automated Releases workflow [is failing](https://github.com/simple-icons/simple-icons-website/actions/runs/1542135316) because default NodeJS version in Github Actions has been updated to v16 this week, see https://github.com/actions/virtual-environments/issues/4446, so pin to 12 until April, 2022, when we should update all our CI workflows in all repos to v14 or v16.