### PR TITLE
🐛 fix searchbar lost focus after clearing

### DIFF
--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -53,6 +53,7 @@ export default function initSearch(history, document, ordering, domUtils) {
     event.preventDefault();
     $searchInput.value = '';
     search('');
+    $searchInput.focus();
   });
 
   // Load search query if present


### PR DESCRIPTION
Summary
- Focus on seach input after clearing the seachbar.
---
Fixes #162 