### PR TITLE
Fix control hiding part of the description on mobiles

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -396,6 +396,7 @@ a {
     justify-content: flex-end;
     margin-bottom: 0.5rem;
     position: relative;
+    top: initial;
   }
 }
 

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -396,7 +396,7 @@ a {
     justify-content: flex-end;
     margin-bottom: 0.5rem;
     position: relative;
-    top: initial;
+    top: -1.2rem;
   }
 }
 


### PR DESCRIPTION
This happens with screens of 640px width at least.

### Before

![image](https://user-images.githubusercontent.com/23049315/146675987-d5bdb480-09c3-4d11-b0fd-13ecbbacbb81.png)

### After

![image](https://user-images.githubusercontent.com/23049315/146676083-1823aa98-c41b-4923-8f92-5e9b121b1e52.png)
