### PR TITLE
Implement lazy loading with relative links to icons SVGs

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -310,7 +310,7 @@ html(lang='en-US')
                 disabled
               )
                 img.icon-preview(
-                  src=`data:image/svg+xml;base64,${icon.base64Svg}`,
+                  src=`icons/${icon.slug}.svg`,
                   loading='lazy',
                   alt=`${icon.title} icon`
                 )

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -5,7 +5,7 @@ function setCopied($el) {
   setTimeout(() => $el.classList.remove('copied'), COPIED_TIMEOUT);
 }
 
-export default function initCopyButtons(window, document, navigator) {
+export default function initCopyButtons(document, navigator, fetch) {
   const $copyInput = document.getElementById('copy-input');
   const $colorButtons = document.querySelectorAll('.copy-color');
   const $svgButtons = document.querySelectorAll('.copy-svg');
@@ -23,16 +23,20 @@ export default function initCopyButtons(window, document, navigator) {
 
   $svgButtons.forEach(($svgButton) => {
     $svgButton.removeAttribute('disabled');
-    $svgButton.addEventListener('click', (event) => {
+    $svgButton.addEventListener('click', async (event) => {
       event.preventDefault();
 
       const $img = $svgButton.querySelector('img');
-      const srcValue = $img.getAttribute('src');
-      const base64Svg = srcValue.replace('data:image/svg+xml;base64,', '');
+      const iconUrl = $img.getAttribute('src');
 
-      const value = window.atob(base64Svg);
-      copyValue(value);
-      setCopied($svgButton);
+      try {
+        const data = await fetch(iconUrl);
+        const svgValue = await data.text();
+        copyValue(svgValue);
+        setCopied($svgButton);
+      } catch (err) {
+        console.error(err);
+      }
     });
   });
 

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -14,7 +14,7 @@ document.body.classList.remove('no-js');
 
 const storage = newStorage(localStorage);
 initColorScheme(document, storage);
-initCopyButtons(window, document, navigator);
+initCopyButtons(document, navigator, fetch);
 const orderingControls = initOrdering(document, storage);
 initSearch(window.history, document, orderingControls, domUtils);
 initDownloadType(document, storage);

--- a/tests/mocks/dom.mock.js
+++ b/tests/mocks/dom.mock.js
@@ -68,7 +68,3 @@ export function newEventMock(opts) {
     composedPath: opts.composedPath ? opts.composedPath : () => '',
   };
 }
-
-export const window = {
-  atob: (base64Str) => Buffer.from(base64Str, 'base64').toString('utf8'),
-};

--- a/tests/mocks/fetch.mock.js
+++ b/tests/mocks/fetch.mock.js
@@ -1,0 +1,18 @@
+export const newFetchTextMock = (value) => {
+  return jest
+    .fn()
+    .mockName('fetch')
+    .mockImplementation((url) => {
+      return new Promise((resolve) => {
+        resolve({
+          text: () => {
+            return new Promise((resolve) => {
+              resolve(value);
+            });
+          },
+        });
+      });
+    });
+};
+
+export const fetch = newFetchTextMock('');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,7 +117,6 @@ module.exports = (env, argv) => {
           icons: displayIcons.map((icon, iconIndex) => {
             const luminance = getRelativeLuminance(`#${icon.hex}`);
             return {
-              base64Svg: Buffer.from(icon.svg).toString('base64'),
               guidelines: icon.guidelines,
               hex: icon.hex,
               indexByAlpha: iconIndex,


### PR DESCRIPTION
Fixes #161 and fixes #143

The implementation for lazy loading in #55 didn't taken into account that lazy loading is not supported by browsers if images are included as base64 data URLs.

This changes the loading by using icon SVG relative links. Now the page loads fast because icons are only loaded as they appear in the screen.

### Before

![lazy-loading-base64-bug](https://user-images.githubusercontent.com/23049315/147140583-ad6e8377-e22a-4b6f-8e65-3d1907a748c3.gif)

### After

![after-lazy-loading](https://user-images.githubusercontent.com/23049315/147158535-6859dfa6-8330-4463-9610-ce617d6e6228.gif)

