### PR TITLE
Fix reused copy button `href` attribute

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -350,7 +350,7 @@ html(lang='en-US')
                 download
               )
                 svg(role='img', viewBox='0 0 24 24')
-                  use(href='cp')
+                  use(href='#cp')
     footer.footer
       .footer-description
         p.


### PR DESCRIPTION
`href` attribute in `use` tag for reused copy button is missing the character `#`,  regression by #174