### PR TITLE
Reduce `preventDefault` calls using `type` attribute in buttons

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -184,6 +184,7 @@ html(lang='en-US')
           .control-field__row
             button#order-alpha.control__button.first__button(
               title='Sort alphabetically',
+              type='button',
               disabled
             )
               svg(
@@ -197,6 +198,7 @@ html(lang='en-US')
                 )
             button#order-color.control__button.last__button(
               title='Sort by color',
+              type='button',
               disabled
             )
               svg(
@@ -211,6 +213,7 @@ html(lang='en-US')
             button#order-relevance.control__button.hidden(
               title='Sort by relevance',
               aria-hidden='true',
+              type='button',
               disabled
             )
               svg(
@@ -227,6 +230,7 @@ html(lang='en-US')
           .control-field__row
             button#color-scheme-light.control__button.first__button(
               title='Light color scheme',
+              type='button',
               disabled
             )
               svg(
@@ -240,6 +244,7 @@ html(lang='en-US')
                 )
             button#color-scheme-dark.control__button(
               title='Dark color scheme',
+              type='button',
               disabled
             )
               svg(
@@ -253,6 +258,7 @@ html(lang='en-US')
                 )
             button#color-scheme-system.control__button.last__button(
               title='System color scheme',
+              type='button',
               disabled
             )
               svg(
@@ -269,6 +275,7 @@ html(lang='en-US')
           .control-field__row
             button#download-svg.control__button.first__button(
               title='download SVG',
+              type='button',
               disabled
             )
               svg(
@@ -282,6 +289,7 @@ html(lang='en-US')
                 )
             button#download-pdf.control__button.last__button(
               title='download PDF',
+              type='button',
               disabled
             )
               svg(

--- a/public/scripts/color-scheme.js
+++ b/public/scripts/color-scheme.js
@@ -26,16 +26,13 @@ export default function initColorScheme(document, storage) {
     selectColorScheme(storedColorScheme);
   }
 
-  $colorSchemeDark.addEventListener('click', (event) => {
-    event.preventDefault();
+  $colorSchemeDark.addEventListener('click', () => {
     selectColorScheme(COLOR_SCHEME_DARK);
   });
-  $colorSchemeLight.addEventListener('click', (event) => {
-    event.preventDefault();
+  $colorSchemeLight.addEventListener('click', () => {
     selectColorScheme(COLOR_SCHEME_LIGHT);
   });
-  $colorSchemeSystem.addEventListener('click', (event) => {
-    event.preventDefault();
+  $colorSchemeSystem.addEventListener('click', () => {
     selectColorScheme(COLOR_SCHEME_SYSTEM);
   });
 

--- a/public/scripts/download-type.js
+++ b/public/scripts/download-type.js
@@ -26,12 +26,10 @@ export default function initDownloadType(document, storage) {
     storage.setItem(STORAGE_KEY_DOWNLOAD_TYPE, DEFAULT_DOWNLOAD_TYPE);
   }
 
-  $downloadPdf.addEventListener('click', (event) => {
-    event.preventDefault();
+  $downloadPdf.addEventListener('click', () => {
     selectDownloadType(PDF_DOWNLOAD_TYPE);
   });
-  $downloadSvg.addEventListener('click', (event) => {
-    event.preventDefault();
+  $downloadSvg.addEventListener('click', () => {
     selectDownloadType(SVG_DOWNLOAD_TYPE);
   });
 

--- a/public/scripts/ordering.js
+++ b/public/scripts/ordering.js
@@ -24,16 +24,13 @@ export default function initOrdering(window, document, storage, domUtils) {
     selectOrdering(storedOrdering);
   }
 
-  $orderAlpha.addEventListener('click', (event) => {
-    event.preventDefault();
+  $orderAlpha.addEventListener('click', () => {
     selectOrdering(ORDER_ALPHA);
   });
-  $orderColor.addEventListener('click', (event) => {
-    event.preventDefault();
+  $orderColor.addEventListener('click', () => {
     selectOrdering(ORDER_COLOR);
   });
-  $orderRelevance.addEventListener('click', (event) => {
-    event.preventDefault();
+  $orderRelevance.addEventListener('click', () => {
     selectOrdering(ORDER_RELEVANCE);
   });
 

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -44,14 +44,12 @@ export default function initSearch(history, document, ordering, domUtils) {
   $searchInput.addEventListener(
     'input',
     debounce((event) => {
-      event.preventDefault();
       const value = $searchInput.value;
       search(value);
     }),
   );
 
   $searchClear.addEventListener('click', (event) => {
-    event.preventDefault();
     $searchInput.value = '';
     search('');
     $searchInput.focus();

--- a/tests/color-scheme.test.js
+++ b/tests/color-scheme.test.js
@@ -45,7 +45,6 @@ describe('Color scheme', () => {
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
-    expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'dark',
@@ -83,7 +82,6 @@ describe('Color scheme', () => {
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
-    expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'light',
@@ -121,7 +119,6 @@ describe('Color scheme', () => {
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
-    expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_COLOR_SCHEME,
       'system',

--- a/tests/ordering.test.js
+++ b/tests/ordering.test.js
@@ -15,6 +15,7 @@ describe('Ordering', () => {
     document.__resetAllMocks();
     localStorage.__resetAllMocks();
     window.__resetAllMocks();
+    domUtils.__resetAllMocks();
   });
 
   it('gets the #order-alpha button', () => {
@@ -49,7 +50,6 @@ describe('Ordering', () => {
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
-    expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
       'order-alpha',
@@ -89,7 +89,6 @@ describe('Ordering', () => {
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
-    expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(localStorage.setItem).toHaveBeenCalledWith(
       STORAGE_KEY_ORDERING,
       'order-color',
@@ -123,7 +122,9 @@ describe('Ordering', () => {
     const clickListener = eventListeners.get('click');
     const event = newEventMock();
     clickListener(event);
-    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+
+    expect(domUtils.sortChildren).toHaveBeenCalledTimes(1);
   });
 
   it('uses alphabetical ordering if no value is stored', () => {

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -86,7 +86,6 @@ describe('Search', () => {
 
       jest.runAllTimers();
 
-      expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(ordering.selectOrdering).toHaveBeenCalledWith(ORDER_RELEVANCE);
       expect(history.replaceState).toHaveBeenCalledWith(
         null,
@@ -125,7 +124,6 @@ describe('Search', () => {
       inputListener(event);
       jest.runAllTimers();
 
-      expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(ordering.resetOrdering).toHaveBeenCalledTimes(1);
       expect(history.replaceState).toHaveBeenCalledWith(
         null,
@@ -161,7 +159,6 @@ describe('Search', () => {
       clickListener(event);
       jest.runAllTimers();
 
-      expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(ordering.resetOrdering).toHaveBeenCalledTimes(1);
       expect(history.replaceState).toHaveBeenCalledWith(
         null,


### PR DESCRIPTION
Replace `preventDefault` for all buttons by `type='button'` attribute, except for those located in each icon, this because it would add a lot of size to the HTML built. 