### PR TITLE
Execute "Verify" workflow on push only against `master` branch

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,9 @@
 name: Verify
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
"Verify" workflow is executed twice on pull requests if the branch is created inside the repository. See #188 for an example.