### PR TITLE
Drop `normalizeSearchTerm` function

### DIFF
--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -1,5 +1,5 @@
 import { ORDER_RELEVANCE } from './ordering.js';
-import { debounce, normalizeSearchTerm } from './utils.js';
+import { debounce } from './utils.js';
 import { Searcher } from 'fast-fuzzy';
 
 const QUERY_PARAMETER = 'q';
@@ -30,9 +30,7 @@ const titleFromIconCard = (iconCard) => {
   // extract title from icon card
   const previewButtonTitle =
     iconCard.children[0].children[0].getAttribute('title');
-  return normalizeSearchTerm(
-    previewButtonTitle.slice(0, previewButtonTitle.length - 4),
-  );
+  return previewButtonTitle.slice(0, previewButtonTitle.length - 4);
 };
 
 export default (history, document, ordering, domUtils) => {

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1,20 +1,3 @@
-const NORMALIZE_SEARCH_TERM_REPLACEMENTS = {
-  đ: 'd',
-  ħ: 'h',
-  ı: 'i',
-  ĸ: 'k',
-  ŀ: 'l',
-  ł: 'l',
-  ß: 'ss',
-  ŧ: 't',
-};
-
-const NORMALIZE_SEARCH_TERM_CHARS_REGEX = RegExp(
-  Object.keys(NORMALIZE_SEARCH_TERM_REPLACEMENTS).join('|'),
-  'g',
-);
-const NORMALIZE_SEARCH_TERM_RANGE_REGEX = RegExp('[\u0300-\u036f]', 'g');
-
 export const debounce = (func, wait, immediate) => {
   let timeout, args, context, timestamp, result;
 

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -46,13 +46,4 @@ export const debounce = (func, wait, immediate) => {
   };
 };
 
-export const normalizeSearchTerm = (value) =>
-  value
-    .replace(
-      NORMALIZE_SEARCH_TERM_CHARS_REGEX,
-      (char) => NORMALIZE_SEARCH_TERM_REPLACEMENTS[char],
-    )
-    .normalize('NFD')
-    .replace(NORMALIZE_SEARCH_TERM_RANGE_REGEX, '');
-
 export const iconHrefToSlug = (href) => /icons\/(.+)\.svg$/.exec(href)[1];

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,9 +1,5 @@
 import { jest } from '@jest/globals';
-import {
-  debounce,
-  normalizeSearchTerm,
-  iconHrefToSlug,
-} from '../public/scripts/utils.js';
+import { debounce, iconHrefToSlug } from '../public/scripts/utils.js';
 
 describe('::debounce', () => {
   beforeAll(() => {
@@ -45,31 +41,6 @@ describe('::debounce', () => {
 
   afterAll(() => {
     jest.useFakeTimers();
-  });
-});
-
-describe('::normalizeSearchTerm', () => {
-  it('normalized string', () => {
-    const input = 'foobar';
-    const result = normalizeSearchTerm(input);
-    expect(result).toEqual(input);
-  });
-
-  it.each([
-    ['àáâãä', 'aaaaa'],
-    ['çčć', 'ccc'],
-    ['èéêë', 'eeee'],
-    ['ìíîï', 'iiii'],
-    ['ñňń', 'nnn'],
-    ['òóôõö', 'ooooo'],
-    ['šś', 'ss'],
-    ['ùúûü', 'uuuu'],
-    ['ýÿ', 'yy'],
-    ['žź', 'zz'],
-    ['đħıĸŀłßŧ', 'dhikllsst'],
-  ])('accented latin characters (%s)', (input, output) => {
-    const result = normalizeSearchTerm(input);
-    expect(result).toEqual(output);
   });
 });
 


### PR DESCRIPTION
The function `normalizeSearchTerm` is not doing anything because the `fast-fuzzy` library made it obsolete. It had sense in the context of a full match, but is not the case, it should had been removed in #153.