### PR TITLE
Fix styles of deprecated message

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -897,6 +897,7 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
 
 /* Deprecated notice */
 .deprecated {
+  position: relative;
   font-family: var(--font-family-stylized);
 }
 


### PR DESCRIPTION
This bug can be reproduced on Safari and Firefox.

### How to reproduce

1. Use Safari or Firefox
2. Open https://simpleicons.org/?q=appannie

### Bug preview

| Chrome | Safari | Firefox |
| :-: | :-: | :-: |
| <img width="1140" alt="CleanShot 2022-09-28 at 02 19 31@2x" src="https://user-images.githubusercontent.com/8186898/192605587-d51bccfe-495b-4d50-b388-f1381b6636d9.png"> | <img width="1140" alt="CleanShot 2022-09-28 at 02 18 47@2x" src="https://user-images.githubusercontent.com/8186898/192605415-99fc4b4d-2bbd-4d05-9d27-8d84d492a939.png"> | <img width="1140" alt="CleanShot 2022-09-28 at 02 19 03@2x" src="https://user-images.githubusercontent.com/8186898/192605458-941d66a3-cef9-4782-a9e9-0932f8cbdc37.png"> |

