### PR TITLE
Move the compact mode grid to the top in production builds

### DIFF
--- a/locales/zh-HK.po
+++ b/locales/zh-HK.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: simple-icons-website\n"
 "Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
 "POT-Creation-Date: 2022-09-28T13:51:38.923Z\n"
-"PO-Revision-Date: 2022-09-29 23:05+0800\n"
+"PO-Revision-Date: 2022-09-29T15:48:33.956Z\n"
 "Last-Translator: @LitoMore <https://github.com/LitoMore>\n"
 "Language-Team: zh-HK <https://github.com/simple-icons>\n"
 "Language: zh-HK\n"
@@ -124,9 +124,6 @@ msgstr "Twitter logo"
 msgid "Share this on Twitter!"
 msgstr "分享至 Twitter"
 
-msgid "website repository"
-msgstr "網站項目"
-
 msgid "Made with ❤️ on GitHub"
 msgstr "Made with ❤️ on GitHub"
 
@@ -165,3 +162,6 @@ msgstr "查看 $iconTitle"
 
 msgid "Report $iconTitle as outdated"
 msgstr "報告 $iconTitle 已過時"
+
+msgid "Website repository"
+msgstr "網站項目"

--- a/locales/zh-TW.po
+++ b/locales/zh-TW.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: simple-icons-website\n"
 "Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
 "POT-Creation-Date: 2022-09-28T14:14:50.054Z\n"
-"PO-Revision-Date: 2022-09-29 23:06+0800\n"
+"PO-Revision-Date: 2022-09-29T15:48:33.956Z\n"
 "Last-Translator: @LitoMore <https://github.com/LitoMore>\n"
 "Language-Team: zh-TW <https://github.com/simple-icons>\n"
 "Language: zh-TW\n"
@@ -124,9 +124,6 @@ msgstr "Twitter logo"
 msgid "Share this on Twitter!"
 msgstr "分享至 Twitter"
 
-msgid "website repository"
-msgstr "網站項目"
-
 msgid "Made with ❤️ on GitHub"
 msgstr "Made with ❤️ on GitHub"
 
@@ -165,3 +162,6 @@ msgstr "查看 $iconTitle"
 
 msgid "Report $iconTitle as outdated"
 msgstr "報告 $iconTitle 已過時"
+
+msgid "Website repository"
+msgstr "網站項目"

--- a/public/index.pug
+++ b/public/index.pug
@@ -498,5 +498,10 @@ html(lang=lang)
         p.
           #[a(title=`${ t_('Website repository') }`, href='https://github.com/simple-icons/simple-icons-website') #{ t_('Made with ❤️ on GitHub') }]
     input#copy-input.hidden(aria-hidden='true', tabindex='-1')
+
+  // In production builds we have the carbonads ad and we don't
+  // want to make it smaller in compact mode. So we move the grid
+  // (including the ad) to the top 5rem, putting the grid just belo
+  // the controls:
   if mode != 'development'
     style .layout-compact .grid { top: -5rem; position: relative; }

--- a/public/index.pug
+++ b/public/index.pug
@@ -504,4 +504,4 @@ html(lang=lang)
   // (including the ad) to the top 5rem, putting the grid just belo
   // the controls:
   if mode != 'development'
-    style .layout-compact .grid { top: -5rem; position: relative; }
+    style .layout-compact .grid { position: relative; top: -4rem; }

--- a/public/index.pug
+++ b/public/index.pug
@@ -498,3 +498,5 @@ html(lang=lang)
         p.
           #[a(title=`${ t_('Website repository') }`, href='https://github.com/simple-icons/simple-icons-website') #{ t_('Made with ❤️ on GitHub') }]
     input#copy-input.hidden(aria-hidden='true', tabindex='-1')
+  if mode != 'development'
+    style .layout-compact .grid { top: -5rem; position: relative; }

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -791,7 +791,10 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   text-align: center;
 }
 @media (max-width: 1280px) {
-  #carbonads {
+  .layout-compact #carbonads {
+    grid-column: -3 / -1;
+  }
+  .layout-comfortable #carbonads {
     grid-column: -2 / -1;
   }
 }

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -594,6 +594,10 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   color: var(--color-link-visited);
 }
 
+#carbonads {
+  z-index: 12;
+}
+
 #carbonads,
 .grid-item {
   background-color: var(--color-background-card);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -435,6 +435,7 @@ export default async (env, argv) => {
             languageOfTheBuild: lang,
             languages,
             languageNames: languageNamesObject,
+            mode: argv.mode,
           },
           minify:
             argv.mode === 'development'


### PR DESCRIPTION
Fixes #245 

### After

![image](https://user-images.githubusercontent.com/23049315/193078006-1f28a1ff-b509-4909-9ede-79a48dafc604.png)

Also increases the space between the ad and the grid (https://github.com/simple-icons/simple-icons-website/pull/246/commits/47e03aacb8ed36ccaa9ca5ff67ff3b008ecd0d8a)