### PR TITLE
Remove `pre-push` hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname $0)/_/husky.sh"
-
-npm run lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,5 +2,3 @@
 . "$(dirname $0)/_/husky.sh"
 
 npm run lint
-npm run build
-npm run test:unit


### PR DESCRIPTION
~~The `build` and `test:unit` take a very long time at the `pre-push` state. It's not necessary to make the production build and unit test before every push.~~

Remove the whole `pre-push` hook.