### PR TITLE
Fix icon colors

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -69,7 +69,7 @@ html(lang=lang)
     .detail_modal.detail__top.hidden
       .detail-body 
         .detail-body__left
-          img#icon-preview
+          img.icon-preview
         .detail-body__right
           h2#icon-title
           button#icon-color

--- a/public/scripts/modal.js
+++ b/public/scripts/modal.js
@@ -43,7 +43,8 @@ export default (document, domUtils, iconsData) => {
       }`,
     );
     $hexContainer.innerText = `#${icon.hex}`;
-    $detailBody.querySelector('img#icon-preview').src = $iconImage.src;
+    $detailBody.querySelector('.detail_modal img.icon-preview').src =
+      $iconImage.src;
     $detailBody.querySelector('#icon-title').innerText = icon.title;
     $detailBody.querySelector('#icon-source').setAttribute('href', icon.source);
 

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -1099,16 +1099,12 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
   height: 161px;
 }
 
-.detail_modal #icon-preview {
+.detail_modal .icon-preview {
   width: 80%;
   position: relative;
   left: 20px;
   margin-bottom: 20px;
   cursor: default;
-}
-
-body:not(.light) .detail_modal #icon-preview {
-  filter: invert(1);
 }
 
 .detail_modal #icon-title {


### PR DESCRIPTION
### Bug preview

<img width="659" alt="CleanShot 2022-09-30 at 23 34 21@2x" src="https://user-images.githubusercontent.com/8186898/193305776-f8b9458e-fa68-45f9-9783-927699635e87.png">

### How to reproduce

1. Open https://simpleicons.org
2. Change your system appearance settings to light mode
3. Change page color scheme to `system color scheme`
4. Open the detail view for an icon