### PR TITLE
Adjust `icon request` and `report oudated` buttons

### DIFF
--- a/locales/es.po
+++ b/locales/es.po
@@ -1,16 +1,17 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simple-icons-website\n"
+"Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
+"POT-Creation-Date: 2022-09-25T01:25:24.834Z\n"
+"PO-Revision-Date: 2022-10-02 16:42+0800\n"
+"Last-Translator: @mondeja <https://github.com/mondeja>\n"
+"Language-Team: es <https://github.com/simple-icons>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language-Team: es <https://github.com/simple-icons>\n"
-"Last-Translator: @mondeja <https://github.com/mondeja>\n"
-"Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
-"Language: es\n"
-"POT-Creation-Date: 2022-09-25T01:25:24.834Z\n"
-"PO-Revision-Date: 2022-09-28T14:06:20.828Z\n"
-"MIME-Version: 1.0\n"
+"X-Generator: Poedit 3.1.1\n"
 
 msgid "Extension"
 msgstr "Extensión"
@@ -150,12 +151,6 @@ msgstr "Descargar SVG coloreado"
 msgid "Download PDF"
 msgstr "Descargar PDF"
 
-msgid "Report $iconTitle as outdated"
-msgstr "Reportar $iconTitle como desactualizado"
-
-msgid "Report icon as outdated"
-msgstr "Reportar icono desactualizado"
-
 msgid "It will be removed at version $version"
 msgstr "Será eliminado en la versión $version"
 
@@ -164,3 +159,9 @@ msgstr "sin directrices de marca"
 
 msgid "no icon license"
 msgstr "sin licencia de icono"
+
+msgid "Icon outdated?"
+msgstr "¿Icono obsoleto?"
+
+msgid "Report outdated icon"
+msgstr "Informar de un icono obsoleto"

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -1,16 +1,17 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simple-icons-website\n"
+"Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
+"POT-Creation-Date: 2022-09-25T01:25:24.834Z\n"
+"PO-Revision-Date: 2022-10-02 16:42+0800\n"
+"Last-Translator: @mondeja <https://github.com/mondeja>\n"
+"Language-Team: fr <https://github.com/simple-icons>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language-Team: fr <https://github.com/simple-icons>\n"
-"Last-Translator: @mondeja <https://github.com/mondeja>\n"
-"Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
-"Language: fr\n"
-"POT-Creation-Date: 2022-09-25T01:25:24.834Z\n"
-"PO-Revision-Date: 2022-09-28T14:06:03.221Z\n"
-"MIME-Version: 1.0\n"
+"X-Generator: Poedit 3.1.1\n"
 
 msgid "Extension"
 msgstr "Extension"
@@ -150,12 +151,6 @@ msgstr "Télécharger SVG coloré"
 msgid "Download PDF"
 msgstr "Télécharger PDF"
 
-msgid "Report $iconTitle as outdated"
-msgstr "Signaler $iconTitle comme obsolète"
-
-msgid "Report icon as outdated"
-msgstr "Signaler l'icône comme obsolète"
-
 msgid "It will be removed at version $version"
 msgstr "Il sera supprimé à la version $version"
 
@@ -164,3 +159,9 @@ msgstr "aucune directive de marque"
 
 msgid "no icon license"
 msgstr "aucune licence d'icône"
+
+msgid "Icon outdated?"
+msgstr "Icône périmée ?"
+
+msgid "Report outdated icon"
+msgstr "Signaler une icône périmée"

--- a/locales/it.po
+++ b/locales/it.po
@@ -1,16 +1,17 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: simple-icons-website\n"
+"Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
+"POT-Creation-Date: 2022-09-26T15:39:06.158Z\n"
+"PO-Revision-Date: 2022-10-02 16:42+0800\n"
+"Last-Translator: @mondeja <https://github.com/mondeja>\n"
+"Language-Team: it <https://github.com/simple-icons>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language-Team: it <https://github.com/simple-icons>\n"
-"Last-Translator: @mondeja <https://github.com/mondeja>\n"
-"Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
-"Language: it\n"
-"POT-Creation-Date: 2022-09-26T15:39:06.158Z\n"
-"MIME-Version: 1.0\n"
-"Project-Id-Version: simple-icons-website\n"
-"PO-Revision-Date: 2022-09-28T14:06:03.221Z\n"
+"X-Generator: Poedit 3.1.1\n"
 
 msgid "$nIcons Free SVG icons for popular brands"
 msgstr "$nIcons icone SVG gratuite per marchi famosi"
@@ -150,12 +151,6 @@ msgstr "Scarica SVG colorato"
 msgid "Download PDF"
 msgstr "Scarica PDF"
 
-msgid "Report $iconTitle as outdated"
-msgstr "Segnala $iconTitle come obsoleto"
-
-msgid "Report icon as outdated"
-msgstr "Segnala icona come obsoleta"
-
 msgid "It will be removed at version $version"
 msgstr "Sarà rimosso nella versione $version"
 
@@ -164,3 +159,9 @@ msgstr "nessuna guida del marchio"
 
 msgid "no icon license"
 msgstr "nessuna licenza dell'icona"
+
+msgid "Icon outdated?"
+msgstr "Icona obsoleta?"
+
+msgid "Report outdated icon"
+msgstr "Segnala un'icona obsoleta"

--- a/locales/zh-CN.po
+++ b/locales/zh-CN.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: simple-icons-website\n"
 "Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
 "POT-Creation-Date: 2022-09-27T13:42:46.869Z\n"
-"PO-Revision-Date: 2022-09-29 23:12+0800\n"
+"PO-Revision-Date: 2022-10-02 16:42+0800\n"
 "Last-Translator: @LitoMore <https://github.com/LitoMore>\n"
 "Language-Team: zh-CN <https://github.com/simple-icons>\n"
 "Language: zh-CN\n"
@@ -139,9 +139,6 @@ msgstr "下载彩色 SVG"
 msgid "Download PDF"
 msgstr "下载 PDF"
 
-msgid "Report icon as outdated"
-msgstr "报告图标过时"
-
 msgid "Layout"
 msgstr "布局"
 
@@ -154,9 +151,6 @@ msgstr "紧凑"
 msgid "view $iconTitle"
 msgstr "查看 $iconTitle"
 
-msgid "Report $iconTitle as outdated"
-msgstr "报告 $iconTitle 过时"
-
 msgid "It will be removed at version $version"
 msgstr "将在 $version 中删除"
 
@@ -165,3 +159,9 @@ msgstr "缺少品牌指南"
 
 msgid "no icon license"
 msgstr "缺少图标许可证"
+
+msgid "Icon outdated?"
+msgstr "有图标过时了吗？"
+
+msgid "Report outdated icon"
+msgstr "报告图标过时"

--- a/locales/zh-HK.po
+++ b/locales/zh-HK.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: simple-icons-website\n"
 "Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
 "POT-Creation-Date: 2022-09-28T13:51:38.923Z\n"
-"PO-Revision-Date: 2022-09-29T15:48:33.956Z\n"
+"PO-Revision-Date: 2022-10-02 16:41+0800\n"
 "Last-Translator: @LitoMore <https://github.com/LitoMore>\n"
 "Language-Team: zh-HK <https://github.com/simple-icons>\n"
 "Language: zh-HK\n"
@@ -145,9 +145,6 @@ msgstr "下載彩色 SVG"
 msgid "Download PDF"
 msgstr "下載 PDF"
 
-msgid "Report icon as outdated"
-msgstr "報告圖標已過時"
-
 msgid "Layout"
 msgstr "佈局"
 
@@ -160,8 +157,11 @@ msgstr "緊湊"
 msgid "view $iconTitle"
 msgstr "查看 $iconTitle"
 
-msgid "Report $iconTitle as outdated"
-msgstr "報告 $iconTitle 已過時"
-
 msgid "Website repository"
 msgstr "網站項目"
+
+msgid "Icon outdated?"
+msgstr "有圖標過時了？"
+
+msgid "Report outdated icon"
+msgstr "報告過時的圖標"

--- a/locales/zh-TW.po
+++ b/locales/zh-TW.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: simple-icons-website\n"
 "Report-Msgid-Bugs-To: https://github.com/simple-icons/simple-icons-website/issues\n"
 "POT-Creation-Date: 2022-09-28T14:14:50.054Z\n"
-"PO-Revision-Date: 2022-09-29T15:48:33.956Z\n"
+"PO-Revision-Date: 2022-10-02 16:41+0800\n"
 "Last-Translator: @LitoMore <https://github.com/LitoMore>\n"
 "Language-Team: zh-TW <https://github.com/simple-icons>\n"
 "Language: zh-TW\n"
@@ -145,9 +145,6 @@ msgstr "下載彩色 SVG"
 msgid "Download PDF"
 msgstr "下載 PDF"
 
-msgid "Report icon as outdated"
-msgstr "報告圖標已過時"
-
 msgid "Layout"
 msgstr "佈局"
 
@@ -160,8 +157,11 @@ msgstr "緊湊"
 msgid "view $iconTitle"
 msgstr "查看 $iconTitle"
 
-msgid "Report $iconTitle as outdated"
-msgstr "報告 $iconTitle 已過時"
-
 msgid "Website repository"
 msgstr "網站項目"
+
+msgid "Icon outdated?"
+msgstr "有圖標過時了？"
+
+msgid "Report outdated icon"
+msgstr "報告過時的圖標"

--- a/public/index.pug
+++ b/public/index.pug
@@ -454,8 +454,8 @@ html(lang=lang)
               )
                 svg(role='img', viewBox='0 0 24 24')
                   use(href='#cp')
-      p.report-link #{ t_('Icon missing?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=new+icon&template=icon_request.yml') #{ t_('Submit a request') }]
-      p.report-link #{ t_('Icon outdated?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=icon+outdated&template=icon_update.yml') #{ t_('Report outdated icon') }]
+      p#icon-missing.report-link #{ t_('Icon missing?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=new+icon&template=icon_request.yml') #{ t_('Submit a request') }]
+      p#icon-outdated.report-link #{ t_('Icon outdated?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=icon+outdated&template=icon_update.yml') #{ t_('Report outdated icon') }]
     footer.footer
       .footer-description
         //- prettier-ignore

--- a/public/index.pug
+++ b/public/index.pug
@@ -88,7 +88,6 @@ html(lang=lang)
         a#icon-download-svg.detail-button(role='button', download) #{ t_('Download SVG') }
         a#icon-download-color-svg.detail-button(role='button', download) #{ t_('Download colored SVG') }
         a#icon-download-pdf.detail-button(role='button', download) #{ t_('Download PDF') }
-        a#icon-report.report__icon.detail-button(role='button') #{ t_('Report icon as outdated') }
 
     header.header
       ul.header__list
@@ -383,13 +382,6 @@ html(lang=lang)
                   d='M2 5.5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-13zm9 0H4v3h7v-3zm2 0v3h7v-3h-7zm7 5h-7v3h7v-3zm0 5h-7v3h7v-3zm-9 3v-3H4v3h7zm-7-5h7v-3H4v3z'
                 )
       ul.grid
-        li.grid-item--if-empty.hidden(
-          aria-hidden='true',
-          order-color=-1,
-          order-alpha=-1
-        )
-          p #{ t_('Icon missing?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?labels=new+icon&template=icon_request.yml&title=Request%3A+') #{ t_('Submit a request') }]
-
         //- This script adds an extra element after itself.
         script#_carbonads_js(
           async,
@@ -462,13 +454,8 @@ html(lang=lang)
               )
                 svg(role='img', viewBox='0 0 24 24')
                   use(href='#cp')
-              a.report__icon.grid-item__button(
-                href=`https://github.com/simple-icons/simple-icons/issues/new?labels=icon+outdated&template=icon_update.md&title=Update%20${icon.title}%20icon`,
-                role='button',
-                title=`${ t_('Report $iconTitle as outdated').replace('$iconTitle', icon.localizedTitle || icon.title) }`
-              )
-                svg(role='img', viewBox='0 0 24 24')
-                  use(href='#fg')
+      p.report-link #{ t_('Icon missing?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=new+icon&template=icon_request.yml') #{ t_('Submit a request') }]
+      p.report-link #{ t_('Icon outdated?') } #[a(href='https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=icon+outdated&template=icon_update.yml') #{ t_('Report outdated icon') }]
     footer.footer
       .footer-description
         //- prettier-ignore

--- a/public/scripts/modal.js
+++ b/public/scripts/modal.js
@@ -108,12 +108,6 @@ export default (document, domUtils, iconsData) => {
     $detailFooter
       .querySelector('#icon-download-pdf')
       .setAttribute('href', `./icons/${icon.slug}.pdf`);
-    $detailFooter
-      .querySelector('#icon-report')
-      .setAttribute(
-        'href',
-        `https://github.com/simple-icons/simple-icons/issues/new?labels=icon+outdated&template=icon_update.md&title=Update%20${icon.title}%20icon`,
-      );
 
     DETAILS_MODAL_OPENED = true;
     e.stopPropagation();

--- a/public/scripts/search.js
+++ b/public/scripts/search.js
@@ -51,8 +51,6 @@ export default (history, document, ordering, domUtils) => {
   const $orderColor = document.getElementById('order-color');
   const $orderRelevance = document.getElementById('order-relevance');
 
-  const $gridItemIfEmpty = document.querySelector('.grid-item--if-empty');
-
   // when loaded for first time, all icon nodes exist in the DOM
   const $icons = document.querySelectorAll('.grid-item');
 
@@ -65,7 +63,7 @@ export default (history, document, ordering, domUtils) => {
   function getNonIcons() {
     const nonIcons = [];
     for (const node of document.querySelector('ul.grid').children) {
-      // grid-item-if-empty and other like carbon ads
+      // carbon ads
       if (!node.classList.contains('grid-item')) {
         nonIcons.push(node);
       } else {
@@ -83,7 +81,6 @@ export default (history, document, ordering, domUtils) => {
       domUtils.hideElement($orderRelevance);
       domUtils.removeClass($orderRelevance, 'last__button');
       domUtils.addClass($orderColor, 'last__button');
-      domUtils.hideElement($gridItemIfEmpty);
 
       // add all icons to the grid again
       const $gridChildren = document.querySelector('ul.grid').children;
@@ -109,11 +106,6 @@ export default (history, document, ordering, domUtils) => {
     result = nonIcons.concat(result);
 
     ordering.selectOrdering(ORDER_RELEVANCE, result);
-    if (result.length !== nonIcons.length) {
-      domUtils.hideElement($gridItemIfEmpty);
-    } else {
-      domUtils.showElement($gridItemIfEmpty);
-    }
   };
 
   $searchInput.disabled = false;

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -574,24 +574,19 @@ body:not(.dark):not(.light) #color-scheme-system:not(:disabled) {
 .grid-top-padding {
   margin-top: 0.1rem;
 }
-.grid-item--if-empty {
-  display: flex;
-  grid-column: 1 / span 2;
-  margin: 0 0.4rem;
-}
-.grid-item--if-empty p {
+p.report-link {
   font-family: var(--font-family-stylized);
   font-size: 0.9rem;
 }
-.grid-item--if-empty a {
+p.report-link a {
   color: var(--color-link);
 }
-.grid-item--if-empty a:focus,
-.grid-item--if-empty a:hover {
+p.report-link a:focus,
+p.report-link a:hover {
   color: var(--color-link-hover);
   text-decoration: underline;
 }
-.grid-item--if-empty a:visited {
+p.report-link a:visited {
   color: var(--color-link-visited);
 }
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -159,19 +159,14 @@ describe('Search', () => {
     },
   );
 
-  it('always show report buttons', async () => {
+  it('show report buttons when icons are missing on search', async () => {
     const $iconMissing = await page.$('#icon-missing');
     const $iconOutdated = await page.$('#icon-outdated');
     expect(await isVisible($iconMissing)).toBeTruthy();
     expect(await isVisible($iconOutdated)).toBeTruthy();
 
     const $searchInput = await page.$('#search-input');
-    await $searchInput.type(' ');
-    expect(await isVisible($iconMissing)).toBeTruthy();
-    expect(await isVisible($iconOutdated)).toBeTruthy();
-
-    await page.$eval('#search-input', (el) => (el.value = ''));
-    await $searchInput.type('litomore');
+    await $searchInput.type('this is definitely not going to match');
     expect(await isVisible($iconMissing)).toBeTruthy();
     expect(await isVisible($iconOutdated)).toBeTruthy();
   });
@@ -277,6 +272,13 @@ describe('Search', () => {
 
     const $orderRelevance = await page.$('#order-relevance');
     expect(await isVisible($orderRelevance)).toBeTruthy();
+  });
+
+  it('shows the "no results" message if no brand was found', async () => {
+    await page.type('#search-input', 'this is definitely not going to match');
+    await page.screenshot({
+      path: path.resolve(ARTIFACTS_DIR, 'desktop_no-search-results.png'),
+    });
   });
 });
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -159,6 +159,23 @@ describe('Search', () => {
     },
   );
 
+  it('always show report buttons', async () => {
+    const $iconMissing = await page.$('#icon-missing');
+    const $iconOutdated = await page.$('#icon-outdated');
+    expect(await isVisible($iconMissing)).toBeTruthy();
+    expect(await isVisible($iconOutdated)).toBeTruthy();
+
+    const $searchInput = await page.$('#search-input');
+    await $searchInput.type(' ');
+    expect(await isVisible($iconMissing)).toBeTruthy();
+    expect(await isVisible($iconOutdated)).toBeTruthy();
+
+    await page.$eval('#search-input', (el) => (el.value = ''));
+    await $searchInput.type('litomore');
+    expect(await isVisible($iconMissing)).toBeTruthy();
+    expect(await isVisible($iconOutdated)).toBeTruthy();
+  });
+
   it('does not show the "order by relevance" button on load', async () => {
     const $orderRelevance = await page.$('#order-relevance');
     expect(await isHidden($orderRelevance)).toBeTruthy();

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -11,7 +11,6 @@ import * as simpleIcons from 'simple-icons/icons';
 
 import {
   getClipboardValue,
-  getAttribute,
   getValue,
   hasClass,
   isDisabled,
@@ -127,16 +126,6 @@ describe('External links', () => {
     );
   });
 
-  it('is possible to click outdated icon link', async () => {
-    const reportIcons = await page.$$('a.report__icon');
-    expect(page).toClick(
-      await getAttribute(
-        reportIcons[Math.floor(Math.random() * reportIcons.length)],
-        'href',
-      ),
-    );
-  });
-
   it('is possible to click language selector', async () => {
     await expect(page).toClick('#language-selector');
   });
@@ -180,11 +169,6 @@ describe('Search', () => {
     expect(await isHidden($searchClear)).toBeTruthy();
   });
 
-  it('does not show the "no results" message on load', async () => {
-    const $gridItemIfEmpty = await page.$('.grid-item--if-empty');
-    expect(await isHidden($gridItemIfEmpty)).toBeTruthy();
-  });
-
   it('shows the "order by relevance" button on search', async () => {
     const $searchInput = await page.$('#search-input');
     await $searchInput.type('adobe');
@@ -207,11 +191,6 @@ describe('Search', () => {
 
     const $body = await page.$('body');
     expect(await hasClass($body, 'order-relevance')).toBeTruthy();
-  });
-
-  it('does not show the "no results" message on search', async () => {
-    const $gridItemIfEmpty = await page.$('.grid-item--if-empty');
-    expect(await isHidden($gridItemIfEmpty)).toBeTruthy();
   });
 
   it('resets the search when clicking the "clear search" button', async () => {
@@ -281,27 +260,6 @@ describe('Search', () => {
 
     const $orderRelevance = await page.$('#order-relevance');
     expect(await isVisible($orderRelevance)).toBeTruthy();
-  });
-
-  it('shows the "no results" message if no brand was found', async () => {
-    await page.type('#search-input', 'this is definitely not going to match');
-    await page.screenshot({
-      path: path.resolve(ARTIFACTS_DIR, 'desktop_no-search-results.png'),
-    });
-
-    const $gridItemIfEmpty = await page.$('.grid-item--if-empty');
-    expect(await isVisible($gridItemIfEmpty)).toBeTruthy();
-  });
-
-  it('hides the "no results" message when the search is removed', async () => {
-    const $searchInput = await page.$('#search-input');
-    await $searchInput.type('this is definitely not going to match');
-
-    await $searchInput.click({ clickCount: 3 });
-    await $searchInput.press('Backspace');
-
-    const $gridItemIfEmpty = await page.$('.grid-item--if-empty');
-    expect(await isHidden($gridItemIfEmpty)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
We received some icon update requests without any description since we added a report below the icon:

- https://github.com/simple-icons/simple-icons/issues/7901
- https://github.com/simple-icons/simple-icons/issues/7879
- https://github.com/simple-icons/simple-icons/issues/7880
- https://github.com/simple-icons/simple-icons/issues/7909

Our previous `report outdated icon` link is:

```
https://github.com/simple-icons/simple-icons/issues/new?labels=icon+outdated&template=icon_update.md&title=Update%20${icon.title}%20icon
```

Opening this link does not use any issue template. This is why their description is empty.

BTW, we may not need to add a report button to every icon. Adding a feature not commonly used in such an important position can be cluttered. So let's remove it.

Users usually find our contact information or feedback link at the very bottom of the page. So I moved the report feature to the below of `Submit a request`.

<img align="right" width="130" alt="CleanShot 2022-10-02 at 17 09 35@2x" src="https://user-images.githubusercontent.com/8186898/193446811-d8c06eb6-6e21-41ba-9adb-0fb9e29cecc1.png">

<img align="right" width="130" alt="CleanShot 2022-10-02 at 17 04 32@2x" src="https://user-images.githubusercontent.com/8186898/193446613-908d6e76-05fd-487d-8163-0bb696138f0b.png">

For the `Submit a request`, previously we would only show this link when the search results were empty. But in fact, we are using a fuzzy search library for filtering icons. Like the pictures on the right side.

In this case, we should show them the `Icon missing?`.

I updated those links to issue template links. Now users will see some required forms when creating the issue.
