### PR TITLE
Add opensearch functionality to website

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -29,6 +29,12 @@ html(lang=lang)
     link(rel='apple-touch-icon', href=`${pageUrl}/images/apple-touch-icon.png`)
     link(rel='mask-icon', href=`${pageUrl}/images/logo.svg`, color='#111111')
     link(
+      rel='search',
+      type='application/opensearchdescription+xml',
+      title='Simple Icons',
+      href=`${pageUrl}/opensearch.xml`
+    )
+    link(
       rel='stylesheet',
       href='https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&family=Roboto+Mono:wght@400;600&display=swap'
     )

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,18 @@
+<OpenSearchDescription
+  xmlns="http://a9.com/-/spec/opensearch/1.1/"
+  xmlns:moz="http://www.mozilla.org/2006/browser/search/"
+>
+	<ShortName>Simple Icons</ShortName>
+	<Description>Search SVG icons for popular brands</Description>
+	<InputEncoding>UTF-8</InputEncoding>
+	<Image
+    width="16"
+    height="16"
+    type="image/x-icon"
+  >https://simpleicons.org/images/favicon.ico</Image>
+	<Url
+    type="text/html"
+    method="get"
+    template="https://simpleicons.org/?q={searchTerms}"
+  />
+</OpenSearchDescription>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -400,6 +400,11 @@ export default async (env, argv) => {
               );
             },
           },
+          {
+            // Add opensearch.xml
+            from: path.resolve(ROOT_DIR, 'opensearch.xml'),
+            to: path.resolve(OUT_DIR, 'opensearch.xml'),
+          },
         ],
       }),
       ...languages.map((lang) => {


### PR DESCRIPTION
Simple Icons can be added as a search engine in Firefox and Edge