### PR TITLE
Fix focused detail buttons color

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -1179,7 +1179,8 @@ p.report-link a:visited {
   text-align: center;
 }
 
-.detail-footer a:hover {
+.detail-footer a:hover,
+.detail-footer a:focus {
   color: var(--color-button-text-hover);
   background: var(--color-button-hover);
 }


### PR DESCRIPTION
The color of detail's buttons when are focused is a light gray, so are not seen by not contrasting with the white background.