### PR TITLE
Add support for copying slug

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -433,7 +433,9 @@ html(lang=lang)
                   rel='noopener',
                   target='_blank'
                 ) #{ icon.license.type }
-              h2.grid-item__title #{ icon.localizedTitle || icon.title }
+              h2.grid-item__title.copy-button.copy-slug(
+                data-slug=`${ icon.slug }`
+              ) #{ icon.localizedTitle || icon.title }
             .grid-item__footer
               button(
                 class=`grid-item__color copy-button copy-color ${icon.light ? "contrast-light" : "contrast-dark"}`,

--- a/public/index.pug
+++ b/public/index.pug
@@ -433,9 +433,7 @@ html(lang=lang)
                   rel='noopener',
                   target='_blank'
                 ) #{ icon.license.type }
-              h2.grid-item__title.copy-button.copy-slug(
-                data-slug=`${ icon.slug }`
-              ) #{ icon.localizedTitle || icon.title }
+              h2.grid-item__title.copy-button.copy-slug #{ icon.localizedTitle || icon.title }
             .grid-item__footer
               button(
                 class=`grid-item__color copy-button copy-color ${icon.light ? "contrast-light" : "contrast-dark"}`,

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -1,3 +1,5 @@
+import { iconHrefToSlug } from './utils.js';
+
 const COPIED_TIMEOUT = 1000;
 
 const setCopied = ($el) => {
@@ -45,8 +47,11 @@ export default (document, navigator, fetch) => {
 
   const onClickSlugButton = (event) => {
     event.preventDefault();
-    const iconSlug = event.target.dataset.slug;
-    copyValue(iconSlug);
+    const href = event.target.parentNode.parentNode
+      .querySelector('a[role="button"][download]')
+      .getAttribute('href');
+    const slug = iconHrefToSlug(href);
+    copyValue(slug);
     setCopied(event.target);
   };
 

--- a/public/scripts/copy.js
+++ b/public/scripts/copy.js
@@ -9,6 +9,7 @@ export default (document, navigator, fetch) => {
   const $copyInput = document.getElementById('copy-input');
   const $colorButtons = document.querySelectorAll('.copy-color');
   const $svgButtons = document.querySelectorAll('.copy-svg');
+  const $slugButtons = document.querySelectorAll('.copy-slug');
 
   const copyValue = (value) => {
     if (navigator.clipboard) {
@@ -42,6 +43,13 @@ export default (document, navigator, fetch) => {
     }
   };
 
+  const onClickSlugButton = (event) => {
+    event.preventDefault();
+    const iconSlug = event.target.dataset.slug;
+    copyValue(iconSlug);
+    setCopied(event.target);
+  };
+
   $colorButtons.forEach(($colorButton) => {
     $colorButton.removeAttribute('disabled');
     $colorButton.addEventListener('click', onClickColorButton);
@@ -50,5 +58,10 @@ export default (document, navigator, fetch) => {
   $svgButtons.forEach(($svgButton) => {
     $svgButton.removeAttribute('disabled');
     $svgButton.addEventListener('click', onClickSvgButton);
+  });
+
+  $slugButtons.forEach(($slugButton) => {
+    $slugButton.removeAttribute('disabled');
+    $slugButton.addEventListener('click', onClickSlugButton);
   });
 };

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -639,6 +639,7 @@ p.report-link a:visited {
   line-height: 1.5rem;
   margin: 0.4rem 0;
   padding-right: 1rem;
+  position: relative;
 }
 
 .layout-compact .grid-item__title {
@@ -648,6 +649,7 @@ p.report-link a:visited {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  position: relative;
 }
 
 .copy-svg::before {
@@ -656,6 +658,13 @@ p.report-link a:visited {
 
   /* Make this element behave as text when JS is disabled */
   cursor: default;
+}
+.copy-slug::before {
+  background-color: var(--color-background-transparent);
+  background-size: 1.2rem 1.2rem;
+}
+.copy-slug.copy-button::before {
+  background-position: right;
 }
 .copy-color::before {
   background-size: 1.2rem 1.2rem;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -458,6 +458,12 @@ describe('Grid item', () => {
     expect(clipboardValue).toMatch(SVG_REGEX);
   });
 
+  it('copies the slug value when the title is clicked', async () => {
+    await expect(page).toClick('h2.copy-slug');
+    const clipboardValue = await getClipboardValue(page);
+    expect(clipboardValue).toBeTruthy();
+  });
+
   it.each(['download-svg', 'download-pdf'])(
     'is possible to download an icon "%s"',
     async (fileType) => {


### PR DESCRIPTION
This is more convenient for users of `shields.io` and `simple-icons-cdn`.

This allows users to copy the slug by clicking the icon title.