### PR TITLE
Fix Kinopoisk casing

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -141,7 +141,7 @@ describe('Search', () => {
     ['by title', 'adobe', 'Adobe'],
     ['aka alias', 'All Elite Wrestling', 'AEW'],
     ['dup alias', 'GoToWebinar', 'GoToMeeting'],
-    ['loc alias', 'КиноПоиск', 'KinoPoisk'],
+    ['loc alias', 'КиноПоиск', 'Kinopoisk'],
   ])(
     'full match searching %s displays matching icon first',
     async (aliasesProp, typedTitle, expectedTitle) => {


### PR DESCRIPTION
Fixed the casing of "Kinopoisk" in `e2e.test.js`, which [caused issues in the last build](https://github.com/simple-icons/simple-icons-website/actions/runs/7236414451/job/19714951683).