### PR TITLE
Fix website not using correct localized icon title.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,7 @@ const getIconLocalizedTitles = (iconData, languages) => {
   if (iconData.aliases && iconData.aliases.loc) {
     for (const locale of Object.keys(iconData.aliases.loc)) {
       if (languages.includes(locale)) {
-        localizedTitles[locale] = iconData.aliases.loc;
+        localizedTitles[locale] = iconData.aliases.loc[locale];
       }
 
       const universalLocale = locale.slice(


### PR DESCRIPTION
Live version:
![image](https://github.com/simple-icons/simple-icons-website/assets/18349191/02c86d57-cb30-4e5a-89a2-8b056fe61f38)

After fix:
![image](https://github.com/simple-icons/simple-icons-website/assets/18349191/f094a510-f3de-47fe-8516-326423717645)
