### PR TITLE
Use `pull_request_target` event to run verification workflows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
 
 jobs:
   build:


### PR DESCRIPTION
When a PR is executed openning from a fork the `BOT_APP_ID` environment variable is not set. See [this run](https://github.com/simple-icons/simple-icons-website/actions/runs/9156088123/job/25169779098?pr=330) of #330.