### PR TITLE
Adjusted sticky navigation CSS to prevent text overlap at the top of the header

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -364,7 +364,7 @@ a {
   flex-direction: row;
   flex-wrap: wrap-reverse;
   margin: 0 calc(-1 * var(--side-offset)) 1.2rem;
-  padding: 0.8rem var(--side-offset);
+  padding: 0.8rem var(--side-offset) 0.65rem;
   position: sticky;
   top: -1.95rem;
   z-index: 10;

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -366,7 +366,7 @@ a {
   margin: 0 calc(-1 * var(--side-offset)) 1.2rem;
   padding: 0.8rem var(--side-offset);
   position: sticky;
-  top: -1.7rem;
+  top: -1.95rem;
   z-index: 10;
 }
 @media (max-width: 640px) {


### PR DESCRIPTION
I have made a modification to the CSS for the sticky navigation. Previously, when scrolling, a portion of the text would appear at the top of the sticky header.

Live version:
![image](https://github.com/user-attachments/assets/24c4a6f9-cd68-46df-beff-99a8caeb5790)
⏬
After fix:
![image](https://github.com/user-attachments/assets/dec314bc-0e06-4a12-9841-0801bf58050d)
