### PR TITLE
Fix encoding of download colored SVGs

### DIFF
--- a/public/scripts/modal.js
+++ b/public/scripts/modal.js
@@ -120,14 +120,14 @@ export default (document, domUtils) => {
       .then((iconSVG) => {
         const coloredIconSVG = iconSVG.replace(
           'svg',
-          `svg fill="%23${iconCssHex.replace('#', '')}"`,
+          `svg fill="${iconCssHex}"`,
         );
         const $iconDownloadColorSVG = $detailFooter.querySelector(
           '#icon-download-color-svg',
         );
         $iconDownloadColorSVG.setAttribute(
           'href',
-          `data:image/svg+xml,${coloredIconSVG}`,
+          `data:image/svg+xml,${encodeURIComponent(coloredIconSVG)}`,
         );
         $iconDownloadColorSVG.setAttribute('download', `${iconSlug}-color.svg`);
       });


### PR DESCRIPTION
Related to this discussion: https://news.ycombinator.com/item?id=41598301

We should encode the image string for the data URL.