### PR TITLE
No sandboxed puppeteer launch

### DIFF
--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -3,6 +3,7 @@ const process = require('node:process');
 module.exports = {
   launch: {
     headless: process.env.TEST_HEADLESS !== 'false',
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
   },
   server: {
     command: 'npm run serve',


### PR DESCRIPTION
Same as https://github.com/simple-icons/simple-icons-font/pull/215/files

See https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox